### PR TITLE
Works with IP 4.2; updated `compatible` in `of_device_id`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xilinx AXI-Stream FIFO v4.1 IP core driver
+# Xilinx AXI-Stream FIFO v4.1/v4.2 IP core driver
 
 This IP core has read and write AXI-Stream FIFOs, the contents of which can be accessed from the AXI4 memory-mapped interface. This is useful for transferring data from a processor into the FPGA fabric. The driver creates a character device that can be read/written to with standard open/read/write/close.
 

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -1071,6 +1071,7 @@ static int axis_fifo_remove(struct platform_device *pdev)
 
 static const struct of_device_id axis_fifo_of_match[] = {
 	{ .compatible = "xlnx,axi-fifo-mm-s-4.1", },
+	{ .compatible = "xlnx,axi-fifo-mm-s-4.2", },
 	{},
 };
 MODULE_DEVICE_TABLE(of, axis_fifo_of_match);
@@ -1105,4 +1106,4 @@ module_exit(axis_fifo_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Jacob Feder <jacobsfeder@gmail.com>");
-MODULE_DESCRIPTION("Xilinx AXI-Stream FIFO v4.1 IP core driver");
+MODULE_DESCRIPTION("Xilinx AXI-Stream FIFO v4.1/v4.2 IP core driver");


### PR DESCRIPTION
Vivado updated the AXIS Stream FIFO IP core from version 4.1 to 4.2 in Vivado 2018.3.  As the identifier within the device tree contains the version number, an additional compatible field within `of_device_id` is needed for the Linux kernel to associate the driver with the new IP core version.