### PR TITLE
Added poll and non-word read/write functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ ssize_t bytes_read = read(f_rd, &read_buff, 100);
 close(f_wr);
 close(f_rd);
 ```
-
-Data can only be written and read in multiples of words (4 bytes).
-
 By default, read() and write() will block for one second before timing out. You can change this behavior by loading the module with command line arguments "read_timeout" and "write_timeout" (in milliseconds):
 
 `insmod /lib/modules/4.9.0-xilinx-v2017.4/extra/axis-fifo.ko read_timeout=100 write_timeout=5000`
@@ -56,6 +53,10 @@ int f = open("/dev/axis_fifo_43c00000", O_RDWR | O_NONBLOCK);
 ```
 
 See fifo-test.c for more detailed usage code and to test functionality/throughput of your FIFO.
+
+See fifo-test-eth.c for more detailed usage code and to test poll() and non-word boundary writes.
+
+See axis-fifo.txt to see example device tree entry.
 
 # Sysfs direct register access
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ See fifo-test-eth.c for more detailed usage code and to test poll() and non-word
 
 See axis-fifo.txt to see example device tree entry.
 
+## Poll
+
+poll returns POLLOUT only when Transmit Data FIFO Vacancy (TDFV) register > (tx-fifo-depth - tx-fifo-pf-threshold)
+poll returns POLLIN whenever the Receive Data FIFO Occupancy (RDFO) register is NOT empty
+
 # Sysfs direct register access
 
 You can access the IP registers directly if you wish using sysfs. They are located in  

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ See axis-fifo.txt to see example device tree entry.
 
 ## Poll
 
-poll returns POLLOUT only when Transmit Data FIFO Vacancy (TDFV) register > (tx-fifo-depth - tx-fifo-pf-threshold)
-poll returns POLLIN whenever the Receive Data FIFO Occupancy (RDFO) register is NOT empty
+* poll returns POLLOUT only when Transmit Data FIFO Vacancy (TDFV) register > (tx-fifo-depth - tx-fifo-pf-threshold)
+
+* poll returns POLLIN whenever the Receive Data FIFO Occupancy (RDFO) register is NOT empty
 
 # Sysfs direct register access
 

--- a/axis-fifo.txt
+++ b/axis-fifo.txt
@@ -1,0 +1,89 @@
+Xilinx AXI-Stream FIFO v4.1 IP core
+
+This IP core has read and write AXI-Stream FIFOs, the contents of which can
+be accessed from the AXI4 memory-mapped interface. This is useful for
+transferring data from a processor into the FPGA fabric. The driver creates
+a character device that can be read/written to with standard
+open/read/write/close.
+
+See Xilinx PG080 document for IP details.
+
+Currently supports only store-forward mode with a 32-bit
+AXI4-Lite interface. DOES NOT support:
+	- cut-through mode
+	- AXI4 (non-lite)
+
+Required properties:
+- compatible: Should be "xlnx,axi-fifo-mm-s-4.1"
+- interrupt-names: Should be "interrupt"
+- interrupt-parent: Should be <&intc>
+- interrupts: Should contain interrupts lines.
+- reg: Should contain registers location and length.
+- xlnx,axi-str-rxd-protocol: Should be "XIL_AXI_STREAM_ETH_DATA"
+- xlnx,axi-str-rxd-tdata-width: Should be <0x20>
+- xlnx,axi-str-txc-protocol: Should be "XIL_AXI_STREAM_ETH_CTRL"
+- xlnx,axi-str-txc-tdata-width: Should be <0x20>
+- xlnx,axi-str-txd-protocol: Should be "XIL_AXI_STREAM_ETH_DATA"
+- xlnx,axi-str-txd-tdata-width: Should be <0x20>
+- xlnx,axis-tdest-width: AXI-Stream TDEST width
+- xlnx,axis-tid-width: AXI-Stream TID width
+- xlnx,axis-tuser-width: AXI-Stream TUSER width
+- xlnx,data-interface-type: Should be <0x0>
+- xlnx,has-axis-tdest: Should be <0x0> (this feature isn't supported)
+- xlnx,has-axis-tid: Should be <0x0> (this feature isn't supported)
+- xlnx,has-axis-tkeep: Should be <0x0> (this feature isn't supported)
+- xlnx,has-axis-tstrb: Should be <0x0> (this feature isn't supported)
+- xlnx,has-axis-tuser: Should be <0x0> (this feature isn't supported)
+- xlnx,rx-fifo-depth: Depth of RX FIFO in words
+- xlnx,rx-fifo-pe-threshold: RX programmable empty interrupt threshold
+- xlnx,rx-fifo-pf-threshold: RX programmable full interrupt threshold
+- xlnx,s-axi-id-width: Should be <0x4>
+- xlnx,s-axi4-data-width: Should be <0x20>
+- xlnx,select-xpm: Should be <0x0>
+- xlnx,tx-fifo-depth: Depth of TX FIFO in words
+- xlnx,tx-fifo-pe-threshold: TX programmable empty interrupt threshold
+- xlnx,tx-fifo-pf-threshold: TX programmable full interrupt threshold
+- xlnx,use-rx-cut-through: Should be <0x0> (this feature isn't supported)
+- xlnx,use-rx-data: <0x1> if RX FIFO is enabled, <0x0> otherwise
+- xlnx,use-tx-ctrl: Should be <0x0> (this feature isn't supported)
+- xlnx,use-tx-cut-through: Should be <0x0> (this feature isn't supported)
+- xlnx,use-tx-data: <0x1> if TX FIFO is enabled, <0x0> otherwise
+
+Example:
+
+axi_fifo_mm_s_0: axi_fifo_mm_s@43c00000 {
+	compatible = "xlnx,axi-fifo-mm-s-4.1";
+	interrupt-names = "interrupt";
+	interrupt-parent = <&intc>;
+	interrupts = <0 29 4>;
+	reg = <0x43c00000 0x10000>;
+	xlnx,axi-str-rxd-protocol = "XIL_AXI_STREAM_ETH_DATA";
+	xlnx,axi-str-rxd-tdata-width = <0x20>;
+	xlnx,axi-str-txc-protocol = "XIL_AXI_STREAM_ETH_CTRL";
+	xlnx,axi-str-txc-tdata-width = <0x20>;
+	xlnx,axi-str-txd-protocol = "XIL_AXI_STREAM_ETH_DATA";
+	xlnx,axi-str-txd-tdata-width = <0x20>;
+	xlnx,axis-tdest-width = <0x4>;
+	xlnx,axis-tid-width = <0x4>;
+	xlnx,axis-tuser-width = <0x4>;
+	xlnx,data-interface-type = <0x0>;
+	xlnx,has-axis-tdest = <0x0>;
+	xlnx,has-axis-tid = <0x0>;
+	xlnx,has-axis-tkeep = <0x0>;
+	xlnx,has-axis-tstrb = <0x0>;
+	xlnx,has-axis-tuser = <0x0>;
+	xlnx,rx-fifo-depth = <0x200>;
+	xlnx,rx-fifo-pe-threshold = <0x2>;
+	xlnx,rx-fifo-pf-threshold = <0x1fb>;
+	xlnx,s-axi-id-width = <0x4>;
+	xlnx,s-axi4-data-width = <0x20>;
+	xlnx,select-xpm = <0x0>;
+	xlnx,tx-fifo-depth = <0x8000>;
+	xlnx,tx-fifo-pe-threshold = <0x200>;
+	xlnx,tx-fifo-pf-threshold = <0x7ffb>;
+	xlnx,use-rx-cut-through = <0x0>;
+	xlnx,use-rx-data = <0x0>;
+	xlnx,use-tx-ctrl = <0x0>;
+	xlnx,use-tx-cut-through = <0x0>;
+	xlnx,use-tx-data = <0x1>;
+};

--- a/axis-fifo.txt
+++ b/axis-fifo.txt
@@ -31,7 +31,7 @@ Required properties:
 - xlnx,data-interface-type: Should be <0x0>
 - xlnx,has-axis-tdest: Should be <0x0> (this feature isn't supported)
 - xlnx,has-axis-tid: Should be <0x0> (this feature isn't supported)
-- xlnx,has-axis-tkeep: Should be <0x0> (this feature isn't supported)
+- xlnx,has-axis-tkeep: Should be <0x1> 
 - xlnx,has-axis-tstrb: Should be <0x0> (this feature isn't supported)
 - xlnx,has-axis-tuser: Should be <0x0> (this feature isn't supported)
 - xlnx,rx-fifo-depth: Depth of RX FIFO in words
@@ -69,7 +69,7 @@ axi_fifo_mm_s_0: axi_fifo_mm_s@43c00000 {
 	xlnx,data-interface-type = <0x0>;
 	xlnx,has-axis-tdest = <0x0>;
 	xlnx,has-axis-tid = <0x0>;
-	xlnx,has-axis-tkeep = <0x0>;
+	xlnx,has-axis-tkeep = <0x1>;
 	xlnx,has-axis-tstrb = <0x0>;
 	xlnx,has-axis-tuser = <0x0>;
 	xlnx,rx-fifo-depth = <0x200>;

--- a/fifo-eth-loop.c
+++ b/fifo-eth-loop.c
@@ -1,6 +1,6 @@
 /**
  * @file axis-fifo-eth-loop.c
- * @author Jason Gutel
+ * @author Jason Gutel jason.gutel@gmail.com
  *
  * Sets up an echo ping-pong server over a TCP connection. Packets are sent
  * over sockets, sent to the AXI Stream FIFO core (assumed in loopback), and

--- a/fifo-eth-loop.c
+++ b/fifo-eth-loop.c
@@ -1,0 +1,392 @@
+/**
+ * @file axis-fifo-eth-loop.c
+ * @author Jason Gutel
+ *
+ * Sets up an echo ping-pong server over a TCP connection. Packets are sent
+ * over sockets, sent to the AXI Stream FIFO core (assumed in loopback), and
+ * then sent back out over the socket.
+ *
+ * Shows example of using poll() with the kernel module
+ *
+ * @bug No known bugs.
+ **/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include <fcntl.h>              // Flags for open()
+#include <sys/stat.h>           // Open() system call
+#include <sys/types.h>          // Types for open()
+#include <unistd.h>             // Close() system call
+#include <string.h>             // Memory setting and copying
+#include <getopt.h>             // Option parsing
+#include <errno.h>              // Error codes
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
+#include <poll.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+/*----------------------------------------------------------------------------
+ * Internal Definitions
+ *----------------------------------------------------------------------------*/
+#define DEFAULT_MAX_BUF_SIZE_BYTES 1102
+#define DEFAULT_PORT_NO    7777
+
+#define DEBUG
+#if defined(DEBUG)
+        #define DEBUG_PRINT(fmt, args...) printf("DEBUG %s:%d(): " fmt, \
+                __func__, __LINE__, ##args)
+#else
+        #define DEBUG_PRINT(fmt, args...) /* do nothing */
+#endif
+
+struct thread_data {
+    int rc;
+};
+
+pthread_t eth_rx_thread;
+pthread_t fifo_rx_thread;
+
+static volatile bool running = true;
+static int _opt_tcp_port = DEFAULT_PORT_NO;
+static int _opt_max_bytes = DEFAULT_MAX_BUF_SIZE_BYTES;
+static char _opt_dev[255];
+static int writeFifoFd;
+static int readFifoFd;
+static int serverFd;
+static int tcpSocketFd;
+
+static int socket_read_error = 0;
+static int socket_write_error = 0;
+
+static void signal_handler(int signal);
+static void *fifo_rx_thread_fn(void *data);
+static int process_options(int argc, char * argv[]);
+static void print_opts();
+static void display_help(char * progName);
+static void *ethn_rx_thread_fn(void *data);
+static void quit(void);
+
+/*----------------------------------------------------------------------------
+ * Main
+ *----------------------------------------------------------------------------*/
+int main(int argc, char **argv)
+{
+    int rc;
+    struct sockaddr_in tcpAddr;
+    int opt;
+    int addrlen;
+
+    process_options(argc, argv);
+    sleep(1);
+    printf("Begin...\n");
+
+    // Listen to ctrl+c and assert
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+    signal(SIGQUIT, signal_handler);
+
+    /*************/
+    /* open FIFO */
+    /*************/
+    readFifoFd = open(_opt_dev, O_RDONLY);
+    writeFifoFd = open(_opt_dev, O_WRONLY);
+    if (readFifoFd < 0) {
+        printf("Open read failed with error: %s\n", strerror(errno));
+        return -1;
+    }
+    if (writeFifoFd < 0) {
+        printf("Open write failed with error: %s\n", strerror(errno));
+        return -1;
+    }
+
+    /**********************************************/
+    /* Start TCP Server and wait for a connection */
+    /**********************************************/
+    opt=1;
+    addrlen=sizeof(tcpAddr);
+    if ((serverFd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
+        DEBUG_PRINT("socket failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (setsockopt(serverFd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT,
+                  &opt, sizeof(opt))) {
+        DEBUG_PRINT("setsockopt");
+        exit(EXIT_FAILURE);
+    }
+    tcpAddr.sin_family = AF_INET;
+    tcpAddr.sin_addr.s_addr = INADDR_ANY;
+    tcpAddr.sin_port = htons(_opt_tcp_port);
+
+    // Forcefully attaching socket to the port 8080
+    if (bind(serverFd, (struct sockaddr *)&tcpAddr,
+            sizeof(tcpAddr))<0) {
+        DEBUG_PRINT("bind failed");
+        exit(EXIT_FAILURE);
+    }
+
+    if (listen(serverFd, 3) < 0) {
+        DEBUG_PRINT("listen");
+        exit(EXIT_FAILURE);
+    }
+
+    if ((tcpSocketFd = accept(serverFd, (struct sockaddr *)&tcpAddr,
+            (socklen_t*)&addrlen))<0) {
+        DEBUG_PRINT("accept");
+        exit(EXIT_FAILURE);
+    } else {
+        DEBUG_PRINT("accepted client\n\r");
+    }
+
+    /*****************/
+    /* start threads */
+    /*****************/
+
+    /* start thread listening for ethernet packets */
+    rc = pthread_create(&eth_rx_thread, NULL, ethn_rx_thread_fn,
+            (void *)NULL);
+
+    /* start thread listening for fifo receive packets */
+    rc = pthread_create(&fifo_rx_thread, NULL, fifo_rx_thread_fn,
+            (void *)NULL);
+
+    /* perform noops */
+    while (running) {
+       if (socket_read_error || socket_write_error) {
+           DEBUG_PRINT("Error %s socket...\n",socket_read_error ? "reading" : "writing"); 
+           goto ret;
+       }
+       sleep(1);
+    }
+
+ret:
+    printf("SHUTTING DOWN\n");
+    pthread_join(eth_rx_thread, NULL);
+    pthread_join(fifo_rx_thread, NULL);
+    close(writeFifoFd);
+    close(readFifoFd);
+    return rc;
+}
+
+static void quit(void)
+{
+    running = false;
+}
+
+static void *ethn_rx_thread_fn(void *data)
+{
+    int rc;
+    ssize_t bytesSock;
+    ssize_t bytesFifo;
+    int packets_rx, packets_tx;
+    uint8_t buf[_opt_max_bytes+10];
+    struct pollfd fds[2];
+    int packetRead = 0;
+
+    /* shup up compiler */
+    (void)data;
+
+    fds[0].fd = tcpSocketFd;
+    fds[1].fd = writeFifoFd;
+    fds[0].events = POLLIN;
+    fds[1].events = POLLOUT;
+
+    packets_rx = 0;
+    packets_tx = 0;
+
+    while (running) {
+        rc = poll(fds, 2, -1);
+
+        if (rc > 0) {
+            if(packetRead == 0 && (fds[0].revents & POLLIN)) {
+                bytesSock = read(tcpSocketFd, buf, _opt_max_bytes);
+                if (bytesSock > 0) {
+                    packetRead = 1;
+                    packets_rx++;
+                    DEBUG_PRINT("bytes from socket %d\n",bytesSock);
+                } else if (bytesSock == 0) {
+                    DEBUG_PRINT("Connection lost\n");
+                    socket_read_error = 1;
+                    quit();
+                } else {
+                    perror("read");
+                    socket_read_error = 1;
+                    quit();
+                }
+            }
+
+            if (packetRead == 1 && (fds[1].revents & POLLOUT)) {
+                bytesFifo = write(writeFifoFd, buf, bytesSock);
+                if (bytesFifo > 0) {
+                    DEBUG_PRINT("bytes to fifo %d\n",bytesFifo);
+                    packets_tx++;
+                    packetRead = 0;
+                } else {
+                    perror("write");
+                    quit();
+                }
+            }
+        }
+    }
+
+    DEBUG_PRINT("ethernet packets rx : %d, fifo packets tx : %d\n",packets_rx, packets_tx);
+
+    return (void *)0;
+}
+
+static void *fifo_rx_thread_fn(void *data)
+{
+    int rc;
+    ssize_t bytesSock;
+    ssize_t bytesFifo;
+    int packets_rx, packets_tx;
+    uint8_t buf[_opt_max_bytes+10];
+    struct pollfd fds[2];
+    int packetRead = 0;
+
+    /* shup up compiler */
+    (void)data;
+
+    fds[0].fd = tcpSocketFd;
+    fds[1].fd = writeFifoFd;
+    fds[0].events = POLLOUT;
+    fds[1].events = POLLIN;
+
+    packets_rx = 0;
+    packets_tx = 0;
+
+    while (running) {
+        rc = poll(fds, 2, -1);
+
+        if (rc > 0) {
+            if(packetRead == 0 && (fds[1].revents & POLLIN)) {
+                bytesFifo = read(readFifoFd, buf, _opt_max_bytes);
+                if (bytesFifo > 0) {
+                    packetRead = 1;
+                    DEBUG_PRINT("bytes from fifo %d\n",bytesFifo);
+                    packets_rx++;
+                } else {
+                    perror("read");
+                    quit();
+                }
+            }
+
+            if (packetRead == 1 && (fds[0].revents & POLLOUT)) {
+                bytesSock = write(tcpSocketFd, buf, bytesFifo);
+                if (bytesSock > 0) {
+                    DEBUG_PRINT("bytes to socket %d\n",bytesSock);
+                    packets_tx++;
+                    packetRead = 0;
+                } else {
+                    perror("write");
+                    socket_write_error = 1;
+                    quit();
+                }
+            }
+        }
+    }
+
+    DEBUG_PRINT("fifo packets rx : %d, ethernet packets tx : %d\n",packets_rx, packets_tx);
+
+    return (void *)0;
+}
+
+static void signal_handler(int signal)
+{
+    switch (signal) {
+        case SIGINT:
+        case SIGTERM:
+        case SIGQUIT:
+            running = false;
+            break;
+
+        default:
+            break;
+    }
+}
+
+static void display_help(char * progName)
+{
+    printf("Usage : %s [OPTIONS]\n"
+           "\n"
+           "  -h, --help   Print this menu\n"
+           "  -d, --dev    Device to use ... /dev/axis_fifo_0x43c10000\n"
+           "  -b, --bytes  Number of bytes to expect in a packet\n"
+           "  -p, --port   Port number to bind to\n"
+           ,
+           progName
+          );
+}
+
+static void print_opts()
+{
+    printf("Options :\n"
+           "Port    : %d\n"
+           "Bytes   : %d\n"
+           "Dev     : %s\n"
+           ,
+           _opt_tcp_port,
+           _opt_max_bytes,
+           _opt_dev
+          );
+}
+
+static int process_options(int argc, char * argv[])
+{
+        int devProvided = 0;
+
+        for (;;) {
+            int option_index = 0;
+            static const char *short_options = "hd:b:p:";
+            static const struct option long_options[] = {
+                    {"help", no_argument, 0, 'h'},
+                    {"dev", required_argument, 0, 'd'},
+                    {"bytes", required_argument, 0, 'b'},
+                    {"port", required_argument, 0, 'p'},
+                    {0,0,0,0},
+                    };
+
+            int c = getopt_long(argc, argv, short_options,
+            long_options, &option_index);
+
+            if (c == EOF) {
+            break;
+            }
+
+            switch (c) {
+            case 'd':
+                devProvided = 1;
+                strcpy(_opt_dev, optarg);
+                break;
+
+            case 'b':
+                _opt_max_bytes = atoi(optarg);
+                break;
+
+            case 'p':
+                _opt_tcp_port = atoi(optarg);
+                break;
+
+            default:
+            case 'h':
+                display_help(argv[0]);
+                exit(0);
+                break;
+                }
+        }
+
+        if (!devProvided) {
+            printf("Must provide --dev flag...\n");
+            display_help(argv[0]);
+            exit(0);
+        }
+        print_opts();
+
+        return 0;
+}

--- a/fifo-test.c
+++ b/fifo-test.c
@@ -151,22 +151,31 @@ int main(int argc, char *argv[])
 	printf("error condition tests PASSED\n");
 
 	// write non word-boundary sized packet
-	int bufSize = 9;
+	int bufSize = 10;
 	uint8_t bufa[bufSize];
 	uint8_t bufb[bufSize];
-	memset(bufa,0,bufSize);
-	memset(bufb,0,bufSize);
-	for(int i = 0; i < bufSize; i++)
-		bufa[i] = i % 255;
-	bytes_written = write(f_wr, bufa, bufSize);
-	bytes_read = read(f_rd, bufb, bytes_written);
-	for(int i = 0; i < bufSize; i++) {
-		if (bufa[i] != bufb[i]) {
-			printf("bufa[%d]=0x%x != bufb[%d]=0x%x\n",
-					i,bufa[i],i,bufb[i]);
-			printf("non-word boundary read/write FAILED ...\n");
+	for(int i = 4; i < bufSize; i++) {
+		memset(bufa,0,bufSize);
+		memset(bufb,0,bufSize);
+		for(int j = 0; j < i; j++)
+			bufa[j] = j % 255;
+
+		bytes_written = write(f_wr, bufa, i);
+		bytes_read = read(f_rd, bufb, bytes_written);
+		if(bytes_written != bytes_read){
+			printf("non-word boundary read/write FAILED\n");
 			return -1;
 		}
+
+		for(int j = 0; j < i; j++) {
+			if (bufa[j] != bufb[j]) {
+				printf("bufa[%d]=0x%x != bufb[%d]=0x%x\n",
+						j,bufa[j],j,bufb[j]);
+				printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
+				return -1;
+			}
+		}
+
 	}
 	printf("non-word boundary read/write test PASSED\n");
 


### PR DESCRIPTION
Modified axis-fifo.c to :
- support polling from user code
- support non-word aligned read/write capability (any number of bytes)

Modified fifo-test.c to:
- thoroughly test the poll mechanism
- thoroughly test read/write of arbitrary number of bytes

Added fifo-eth-loop.c
- example code setting up a tcp server and using the fifo in loopback to perform echos to a client

Modified readme
- added notes for using poll

Added axis-fifo.txt:
- found on staging in linux repo
- provides solid device-tree reference
- modified to include TKEEP on AXIS interface as it's necessary for non-word read/writes