### PR TITLE
Update poll() and added use of tkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int f = open("/dev/axis_fifo_43c00000", O_RDWR | O_NONBLOCK);
 
 See fifo-test.c for more detailed usage code and to test functionality/throughput of your FIFO.
 
-See fifo-test-eth.c for more detailed usage code and to test poll() and non-word boundary writes.
+See fifo-test-eth.c provided for simple echo server demo using the fifo.
 
 See axis-fifo.txt to see example device tree entry.
 
@@ -85,7 +85,7 @@ rx-min-pkt-size poll will return POLLIN.
 
 Example code using poll is provided in fifo-test.c
 
-**NOTE** ``tx-max-pkt-size`` and ``rx-min-pkt-size`` are defined as WORDS not BYTES.
+**NOTE :** ``tx-max-pkt-size`` and ``rx-min-pkt-size`` are defined as WORDS not BYTES.
 
 # Sysfs direct register access
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ When setting up the device tree the values entered into tx-fifo-pe-threshold and
 
 * POLLIN set when the Receive Data FIFO Occupancy (RDFO) register > rx-fifo-pe-threshold
 
+## Word and Byte read/write alignments and TKEEP
+
+The AXI-Stream protocol requires the TKEEP flag to be enabled in order to process byte width transactions over a 32-bit bus. When the TKEEP flag is NOT used then the FIFO is only able to process on word boundaries. 
+
+The driver supports both modes by use of the has-axis-tkeep flag in the device tree. When it is NOT enabled byte width read/write requests will present an error and not be written to the core. 
+
+fifo-test.c supports testing of both modes.
+
 # Sysfs direct register access
 
 You can access the IP registers directly if you wish using sysfs. They are located in  

--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ See axis-fifo.txt to see example device tree entry.
 
 ## Poll
 
-* poll returns POLLOUT only when Transmit Data FIFO Vacancy (TDFV) register > (tx-fifo-depth - tx-fifo-pf-threshold)
+The poll() mechanism is being implemented by considering a user defined minimum packet size using the FIFO's Programmable Empty Threshold values. When using poll to write to the FIFO it makes sure that this minimum number of bytes are available in the FIFO before asserting POLLOUT. When using poll to read from the FIFO it makes sure this minimum number of bytes are available before asserting POLLIN.
 
-* poll returns POLLIN whenever the Receive Data FIFO Occupancy (RDFO) register is NOT empty
+When setting up the device tree the values entered into tx-fifo-pe-threshold and rx-fifo-pe-threshold will define this behavior.
+
+* POLLOUT set when Transmit Data FIFO Vacancy (TDFV) register > tx-fifo-pe-threshold
+
+* POLLIN set when the Receive Data FIFO Occupancy (RDFO) register > rx-fifo-pe-threshold
 
 # Sysfs direct register access
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,24 @@ fifo-test.c supports testing of both modes.
 
 ## Poll
 
-The poll() mechanism is being implemented by considering a user defined minimum packet size using the FIFO's Programmable Empty Threshold values. When using poll to write to the FIFO it makes sure that this minimum number of bytes are available in the FIFO before asserting POLLOUT. When using poll to read from the FIFO it makes sure this minimum number of bytes are available before asserting POLLIN.
+The poll mechanism works off of the assumption that the user has an idea for a
+minimum and maximum packet size with respect to the AXI-Stream framing. To
+support this there are two entries in the device tree,
 
-When setting up the device tree the values entered into ``tx-fifo-pe-threshold`` and ``rx-fifo-pe-threshold`` will define this behavior. 
+```
+	xlnx,rx-min-pkt-size = <255>; /* 1020 bytes */
+	xlnx,tx-max-pkt-size = <257>; /* 1028 bytes */
+```
 
-**NOTE** ``tx-fifo-pe-threshold`` and ``rx-fifo-pe-threshold`` are defined as WORDS not BYTES.
+When the Transmit Data FIFO Vacancy register (TDFV) is greater than
+tx-max-pkt-size poll will return POLLOUT.
 
-* POLLOUT set when Transmit Data FIFO Vacancy (TDFV) register > tx-fifo-pe-threshold
+When the Receive Data FIFO Occupancy register (RDFO) is greater than
+rx-min-pkt-size poll will return POLLIN.
 
-* POLLIN set when the Receive Data FIFO Occupancy (RDFO) register > rx-fifo-pe-threshold
+Example code using poll is provided in fifo-test.c
+
+**NOTE** ``tx-max-pkt-size`` and ``rx-min-pkt-size`` are defined as WORDS not BYTES.
 
 # Sysfs direct register access
 

--- a/README.md
+++ b/README.md
@@ -58,23 +58,25 @@ See fifo-test-eth.c for more detailed usage code and to test poll() and non-word
 
 See axis-fifo.txt to see example device tree entry.
 
-## Poll
-
-The poll() mechanism is being implemented by considering a user defined minimum packet size using the FIFO's Programmable Empty Threshold values. When using poll to write to the FIFO it makes sure that this minimum number of bytes are available in the FIFO before asserting POLLOUT. When using poll to read from the FIFO it makes sure this minimum number of bytes are available before asserting POLLIN.
-
-When setting up the device tree the values entered into tx-fifo-pe-threshold and rx-fifo-pe-threshold will define this behavior.
-
-* POLLOUT set when Transmit Data FIFO Vacancy (TDFV) register > tx-fifo-pe-threshold
-
-* POLLIN set when the Receive Data FIFO Occupancy (RDFO) register > rx-fifo-pe-threshold
-
 ## Word and Byte read/write alignments and TKEEP
 
 The AXI-Stream protocol requires the TKEEP flag to be enabled in order to process byte width transactions over a 32-bit bus. When the TKEEP flag is NOT used then the FIFO is only able to process on word boundaries. 
 
-The driver supports both modes by use of the has-axis-tkeep flag in the device tree. When it is NOT enabled byte width read/write requests will present an error and not be written to the core. 
+TKEEP must be both enabled on the IP Core and the device-tree by use of the ``has-axis-tkeep = <1>`` entry in the device tree. When it is NOT enabled byte width read/write requests will present an error and not be written to the core. 
 
 fifo-test.c supports testing of both modes.
+
+## Poll
+
+The poll() mechanism is being implemented by considering a user defined minimum packet size using the FIFO's Programmable Empty Threshold values. When using poll to write to the FIFO it makes sure that this minimum number of bytes are available in the FIFO before asserting POLLOUT. When using poll to read from the FIFO it makes sure this minimum number of bytes are available before asserting POLLIN.
+
+When setting up the device tree the values entered into ``tx-fifo-pe-threshold`` and ``rx-fifo-pe-threshold`` will define this behavior. 
+
+**NOTE** ``tx-fifo-pe-threshold`` and ``rx-fifo-pe-threshold`` are defined as WORDS not BYTES.
+
+* POLLOUT set when Transmit Data FIFO Vacancy (TDFV) register > tx-fifo-pe-threshold
+
+* POLLIN set when the Receive Data FIFO Occupancy (RDFO) register > rx-fifo-pe-threshold
 
 # Sysfs direct register access
 

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -354,7 +354,7 @@ static unsigned int axis_poll(struct file *file, poll_table *wait)
         if (ioread32(fifo->base_addr + XLLF_RDFO_OFFSET))
                 mask |= POLLIN | POLLRDNORM;
     	if (ioread32(fifo->base_addr + XLLF_TDFV_OFFSET) > 
-		(fifo->tx_fifo_depth - fifo->tx_fifo_pf_thresh)) {
+		fifo->tx_fifo_pe_thresh) {
                 mask |= POLLOUT;
 	}
 

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -357,10 +357,10 @@ static unsigned int axis_poll(struct file *file, poll_table *wait)
 	unsigned int tdfv;
 	mask = 0;
 
-    if (fifo->has_rx_fifo)
-	poll_wait(file, &axis_read_wait, wait);
-    if (fifo->has_tx_fifo)
-	poll_wait(file, &axis_write_wait, wait);
+	if (fifo->has_rx_fifo)
+		poll_wait(file, &axis_read_wait, wait);
+	if (fifo->has_tx_fifo)
+		poll_wait(file, &axis_write_wait, wait);
 
 	/* user should set the rx-min-pkt-size
 	* in the device tree to indicate when POLLIN will return 

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -45,6 +45,7 @@
 
 #define READ_BUF_SIZE 128U /* read buffer length in words */
 #define WRITE_BUF_SIZE 128U /* write buffer length in words */
+/* #define AXIS_FIFO_DEBUG_PRINT */
 
 /* ----------------------------
  *     IP register offsets
@@ -136,8 +137,13 @@ struct axis_fifo {
 	unsigned int tx_fifo_depth; /* max words in the transmit fifo */
     	unsigned int rx_fifo_pf_thresh; /* programmable full threshold for rx */
     	unsigned int tx_fifo_pf_thresh; /* programmable full threshold for tx */
+	unsigned int rx_fifo_pe_thresh; /* programmable empty threshold for rx */
+	unsigned int tx_fifo_pe_thresh; /* programmable empty threshold for tx */
+	unsigned int tx_max_pkt_size; /* used to trigger poll events */
+	unsigned int rx_min_pkt_size; /* used to trigger poll events */
 	int has_rx_fifo; /* whether the IP has the rx fifo enabled */
 	int has_tx_fifo; /* whether the IP has the tx fifo enabled */
+	int has_tkeep; /* whether the IP has TKEEP enabled or not */
 
 	wait_queue_head_t read_queue; /* wait queue for asynchronos read */
 	spinlock_t read_queue_lock; /* lock for reading waitqueue */
@@ -347,27 +353,35 @@ static unsigned int axis_poll(struct file *file, poll_table *wait)
 {
 	unsigned int mask;
 	struct axis_fifo *fifo = (struct axis_fifo *)file->private_data;
+	unsigned int rdfo;
+	unsigned int tdfv;
 	mask = 0;
 
+    if (fifo->has_rx_fifo)
 	poll_wait(file, &axis_read_wait, wait);
+    if (fifo->has_tx_fifo)
 	poll_wait(file, &axis_write_wait, wait);
 
-	/* user should set the rx fifo programmable empty threshold
+	/* user should set the rx-min-pkt-size
 	* in the device tree to indicate when POLLIN will return 
-	* NOTE : rx_fifo_pe_thresh is in WORDS not BYTES 
+	* NOTE : rx-min-pkt-size is in WORDS not BYTES 
 	*/
-	if (ioread32(fifo->base_addr + XLLF_RDFO_OFFSET) >
-			fifo->rx_fifo_pe_thresh){
-		mask |= POLLIN | POLLRDNORM;
+	if (fifo->has_rx_fifo) {
+		rdfo = ioread32(fifo->base_addr + XLLF_RDFO_OFFSET);
+		if (rdfo > fifo->rx_min_pkt_size){
+			mask |= POLLIN | POLLRDNORM;
+		}		
 	}
 
-	/* user should set the tx fifo programmable empty threshold
+	/* user should set the tx-max-pkt-size
 	* in the device tree to indicate when POLLOUT will return 
-	* NOTE : tx_fifo_pe_thresh is in WORDS not BYTES 
+	* NOTE : tx-max-pkt-size is in WORDS not BYTES 
 	*/
-	if (ioread32(fifo->base_addr + XLLF_TDFV_OFFSET) > 
-			fifo->tx_fifo_pe_thresh) {
-		mask |= POLLOUT;
+	if (fifo->has_tx_fifo) {
+		tdfv = ioread32(fifo->base_addr + XLLF_TDFV_OFFSET);
+		if (tdfv > fifo->tx_max_pkt_size){ 
+			mask |= POLLOUT;
+       		}
 	}
 
 	return mask;
@@ -434,10 +448,25 @@ static ssize_t axis_fifo_read(struct file *f, char __user *buf,
 			bytes_available, len);
 		reset_ip_core(fifo);
 		return -EINVAL;
+    }
+
+	if (!fifo->has_tkeep && bytes_available % sizeof(u32)) {
+		/* this probably can't happen unless IP
+		 * registers were previously mishandled
+		 */
+		dev_err(fifo->dt_device, "received a packet that isn't word-aligned - fifo core will be reset\n");
+		reset_ip_core(fifo);
+		return -EIO;
 	}
 
 	words_available = bytes_available / sizeof(u32);
-        leftover = bytes_available % sizeof(u32);
+
+#ifdef AXIS_FIFO_DEBUG_PRINT
+	dev_err(fifo->dt_device,"read: rdfo : %d ... tdfv : %d ... rlr : %d\n",
+		ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
+		ioread32(fifo->base_addr + XLLF_TDFV_OFFSET),
+		bytes_available);
+#endif
 
 	/* read data into an intermediate buffer, copying the contents
 	 * to userspace when the buffer is full
@@ -461,16 +490,19 @@ static ssize_t axis_fifo_read(struct file *f, char __user *buf,
 		words_available -= copy;
 	}
 
-        if (leftover) {
-                tmp_buf[0] = ioread32(fifo->base_addr +
-                                          XLLF_RDFD_OFFSET);
+	if (fifo->has_tkeep) {
+		leftover = bytes_available % sizeof(u32);
+		if (leftover) {
+			tmp_buf[0] = ioread32(fifo->base_addr +
+				                  XLLF_RDFD_OFFSET);
 
-                if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
-                                 leftover)) {
-                        reset_ip_core(fifo);
-                        return -EFAULT;
-                }
-        }
+			if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
+				         leftover)) {
+				reset_ip_core(fifo);
+				return -EFAULT;
+			}
+		}
+    }
 
 	return bytes_available;
 }
@@ -487,6 +519,12 @@ static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
 	int ret;
 	u32 tmp_buf[WRITE_BUF_SIZE];
         int leftover;
+
+	if (!fifo->has_tkeep && len % sizeof(u32)) {
+		dev_err(fifo->dt_device,
+		    "tried to send a packet that isn't word-aligned\n");
+		return -EINVAL;
+	}
 
 	words_to_write = len / sizeof(u32);
         leftover = len % sizeof(u32);
@@ -544,6 +582,12 @@ static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
 		}
 	}
 
+#ifdef AXIS_FIFO_DEBUG_PRINT
+	dev_err(fifo->dt_device,"write: rdfo : %d ... tdfv : %d\n",
+		ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
+		ioread32(fifo->base_addr + XLLF_TDFV_OFFSET));
+#endif
+
 	/* write data from an intermediate buffer into the fifo IP, refilling
 	 * the buffer with userspace data as needed
 	 */
@@ -565,7 +609,7 @@ static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
 		words_to_write -= copy;
 	}
 
-        if (leftover) {
+	if (fifo->has_tkeep && leftover) {	
                 if (copy_from_user(tmp_buf, buf + copied * sizeof(u32),
                                    leftover)) {
                         reset_ip_core(fifo);
@@ -576,7 +620,7 @@ static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
         }
 
         /* write packet size to fifo */
-        copiedBytes = (!!leftover) ? (copied*sizeof(u32)+leftover) : (copied*sizeof(u32));
+	copiedBytes = (fifo->has_tkeep && !!leftover) ? (copied*sizeof(u32)+leftover) : (copied*sizeof(u32));
         iowrite32(copiedBytes, fifo->base_addr + XLLF_TLR_OFFSET);
 
         return (ssize_t)copiedBytes;
@@ -597,6 +641,7 @@ static irqreturn_t axis_fifo_irq(int irq, void *dw)
 
 			/* wake the reader process if it is waiting */
 			wake_up(&fifo->read_queue);
+			wake_up_interruptible(&axis_read_wait);
 
 			/* clear interrupt */
 			iowrite32(XLLF_INT_RC_MASK & XLLF_INT_ALL_MASK,
@@ -606,6 +651,7 @@ static irqreturn_t axis_fifo_irq(int irq, void *dw)
 
 			/* wake the writer process if it is waiting */
 			wake_up(&fifo->write_queue);
+			wake_up_interruptible(&axis_write_wait);
 
 			iowrite32(XLLF_INT_TC_MASK & XLLF_INT_ALL_MASK,
 				  fifo->base_addr + XLLF_ISR_OFFSET);
@@ -617,11 +663,13 @@ static irqreturn_t axis_fifo_irq(int irq, void *dw)
 		} else if (pending_interrupts & XLLF_INT_TFPE_MASK) {
 			/* transmit fifo programmable empty */
 
+			wake_up_interruptible(&axis_write_wait);
 			iowrite32(XLLF_INT_TFPE_MASK & XLLF_INT_ALL_MASK,
 				  fifo->base_addr + XLLF_ISR_OFFSET);
 		} else if (pending_interrupts & XLLF_INT_RFPF_MASK) {
 			/* receive fifo programmable full */
 
+			wake_up_interruptible(&axis_read_wait);
 			iowrite32(XLLF_INT_RFPF_MASK & XLLF_INT_ALL_MASK,
 				  fifo->base_addr + XLLF_ISR_OFFSET);
 		} else if (pending_interrupts & XLLF_INT_RFPE_MASK) {
@@ -789,6 +837,8 @@ static int axis_fifo_probe(struct platform_device *pdev)
 	unsigned int use_tx_control;
 	unsigned int use_tx_cut_through;
 	unsigned int use_tx_data;
+	unsigned int tx_max_pkt_size;
+	unsigned int rx_min_pkt_size;
 
 	/* ----------------------------
 	 *     init wrapper device
@@ -920,6 +970,12 @@ static int axis_fifo_probe(struct platform_device *pdev)
 	rc = get_dts_property(fifo, "xlnx,tx-fifo-depth", &tx_fifo_depth);
 	if (rc)
 		goto err_unmap;
+	rc = get_dts_property(fifo, "xlnx,tx-max-pkt-size", &tx_max_pkt_size);
+	if (rc)
+		goto err_unmap;
+	rc = get_dts_property(fifo, "xlnx,rx-min-pkt-size", &rx_min_pkt_size);
+	if (rc)
+		goto err_unmap;
 	rc = get_dts_property(fifo, "xlnx,tx-fifo-pe-threshold",
 			      &tx_programmable_empty_threshold);
 	if (rc)
@@ -1009,8 +1065,13 @@ static int axis_fifo_probe(struct platform_device *pdev)
 	fifo->tx_fifo_depth = tx_fifo_depth - 4;
 	fifo->rx_fifo_pf_thresh = rx_programmable_full_threshold;
 	fifo->tx_fifo_pf_thresh = tx_programmable_full_threshold;
-	fifo->has_rx_fifo = use_rx_data;
-	fifo->has_tx_fifo = use_tx_data;
+	fifo->rx_fifo_pe_thresh = rx_programmable_empty_threshold;
+	fifo->tx_fifo_pe_thresh = tx_programmable_empty_threshold;
+	fifo->has_rx_fifo = !!use_rx_data;
+	fifo->has_tx_fifo = !!use_tx_data;
+	fifo->has_tkeep = !!has_tkeep;
+	fifo->tx_max_pkt_size = tx_max_pkt_size;
+	fifo->rx_min_pkt_size = rx_min_pkt_size;
 
 	reset_ip_core(fifo);
 
@@ -1052,10 +1113,10 @@ static int axis_fifo_probe(struct platform_device *pdev)
 	/* create driver file */
 	fifo->device = device_create(axis_fifo_driver_class, NULL, fifo->devt,
 				     NULL, device_name);
-	if (!fifo->device) {
+	if (IS_ERR(fifo->device)) {
 		dev_err(fifo->dt_device,
 			"couldn't create driver file\n");
-		rc = -ENOMEM;
+		rc = PTR_ERR(fifo->device);
 		goto err_chrdev_region;
 	}
 	dev_set_drvdata(fifo->device, fifo);
@@ -1137,6 +1198,8 @@ static int __init axis_fifo_init(void)
 	pr_info("axis-fifo driver loaded with parameters read_timeout = %i, write_timeout = %i\n",
 		read_timeout, write_timeout);
 	axis_fifo_driver_class = class_create(THIS_MODULE, DRIVER_NAME);
+	if (IS_ERR(axis_fifo_driver_class))
+		return PTR_ERR(axis_fifo_driver_class);
 	return platform_driver_register(&axis_fifo_driver);
 }
 

--- a/axis-fifo.txt
+++ b/axis-fifo.txt
@@ -48,6 +48,8 @@ Required properties:
 - xlnx,use-tx-ctrl: Should be <0x0> (this feature isn't supported)
 - xlnx,use-tx-cut-through: Should be <0x0> (this feature isn't supported)
 - xlnx,use-tx-data: <0x1> if TX FIFO is enabled, <0x0> otherwise
+- xlnx,tx-max-pkt-size: defines when poll() returns POLLOUT (tdfv > tx-max-pkt-size)
+- xlnx,rx-min-pkt-size: defines when poll() returns POLLIN (rdfo > rx-min-pkt-size)
 
 Example:
 
@@ -86,4 +88,6 @@ axi_fifo_mm_s_0: axi_fifo_mm_s@43c00000 {
 	xlnx,use-tx-ctrl = <0x0>;
 	xlnx,use-tx-cut-through = <0x0>;
 	xlnx,use-tx-data = <0x1>;
+	xlnx,tx-max-pkt-size = <257>; 
+	xlnx,rx-min-pkt-size = <255>; 
 };

--- a/fifo-test.c
+++ b/fifo-test.c
@@ -178,26 +178,26 @@ int main(int argc, char *argv[])
 		for(int i = 4; i < 16; i++) {
 			memset(bufa,0,MAX_PACKET_SIZE);
 			memset(bufb,0,MAX_PACKET_SIZE);
-		for(int j = 0; j < i; j++)
-			bufa[j] = j % 255;
+			for(int j = 0; j < i; j++)
+				bufa[j] = j % 255;
 
-		bytes_written = write(f_wr, bufa, i);
-		bytes_read = read(f_rd, bufb, bytes_written);
-		if(bytes_written != bytes_read){
+			bytes_written = write(f_wr, bufa, i);
+			bytes_read = read(f_rd, bufb, bytes_written);
+			if(bytes_written != bytes_read){
 				printf("non-word boundary read/write FAILED : bytes_written != bytes_read\n");
-			return -1;
-		}
-
-		for(int j = 0; j < i; j++) {
-			if (bufa[j] != bufb[j]) {
-					printf("\tbufa[%d]=0x%x != bufb[%d]=0x%x\n",
-						j,bufa[j],j,bufb[j]);
-				printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
 				return -1;
 			}
+
+			for(int j = 0; j < i; j++) {
+				if (bufa[j] != bufb[j]) {
+					printf("\tbufa[%d]=0x%x != bufb[%d]=0x%x\n",
+						j,bufa[j],j,bufb[j]);
+					printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
+					return -1;
+				}
+			}
 		}
-	}
-	printf("non-word boundary read/write test PASSED\n");
+		printf("non-word boundary read/write test PASSED\n");
 	}
 
 	// test poll subsystem

--- a/fifo-test.c
+++ b/fifo-test.c
@@ -29,19 +29,21 @@ pass in the number of words to write and the driver device file location(s)
 
 // number of bytes to send in a packet (max is fifo depth * 4)
 #define MAX_PACKET_SIZE 8196
+#define POLL_PACKET_SIZE 1024
 
 int main(int argc, char *argv[])
 {
-	if (argc < 3 || argc > 4) {
-		printf("usage: %s [# words] [read device file] [optional: write device file]\n", argv[0]);
-		printf("		e.g. \"%s 1024 /dev/axis_fifo0\" for loopback configuration\n", argv[0]);
-		printf("		e.g. \"%s 1024 /dev/axis_fifo0 /dev/axis_fifo1\" for passthrough configuration\n", argv[0]);
+	if (argc < 4 || argc > 5) {
+		printf("usage: %s [# words] [tkeep] [read device file] [optional: write device file]\n", argv[0]);
+		printf("		e.g. \"%s 1024 1 /dev/axis_fifo0\" for loopback configuration\n", argv[0]);
+		printf("		e.g. \"%s 1024 1 /dev/axis_fifo0 /dev/axis_fifo1\" for passthrough configuration\n", argv[0]);
 		return -1;
 	}
 
 	// transmitted data string
 	char *data_string;
 	unsigned data_string_len;
+	int rc;
 
 	// device file locations
 	char *read_device_file;
@@ -52,25 +54,33 @@ int main(int argc, char *argv[])
 	// file descriptors
 	int f_rd;
 	int f_wr;
+	int tkeep;
 
 	// first argument is how many words to write
 	unsigned num_words = atoi(argv[1]);
 	data_string_len = num_words*4;
 
-	// second / third arguments are read/write device file names
-	if (argc == 3) {
-		read_device_file = argv[2];
-		write_device_file = argv[2];
-	} else {
-		read_device_file = argv[2];
-		write_device_file = argv[3];
-	}
+	printf("START :\n\n");
 
-	// test error conditions
+	tkeep = atoi(argv[2]);
+	if (!!tkeep)
+		printf("TKEEP enabled ... testing byte boundary read/writes\n");
+	else
+		printf("TKEEP not enabled ... testing word boundary read/writes\n");
+
+	// second / third arguments are read/write device file names
+	if (argc == 4) {
+		read_device_file = argv[3];
+		write_device_file = argv[3];
+	} else {
+		read_device_file = argv[3];
+		write_device_file = argv[4];
+	}
 
 	f_rd = open(read_device_file, O_RDONLY);
 	f_wr = open(write_device_file, O_WRONLY);
 
+	// test error conditions
 	if (f_rd < 0) {
 		printf("Open read failed with error: %s\n", strerror(errno));
 		return -1;
@@ -82,7 +92,8 @@ int main(int argc, char *argv[])
 
 	unsigned eight_bytes[2] = {0xDEADBEEF, 0xDEADBEEF};
 
-	printf("TESTING error conditions...\n");
+	printf("\nTESTING error conditions...\n");
+	fflush(stdout);
 
 	// read buffer too small test
 	bytes_written = write(f_wr, eight_bytes, 8);
@@ -138,6 +149,17 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
+	if (!tkeep) {
+		// write misaligned packet
+		// this will only fail if TKEEP is NOT enabled
+		bytes_written = write(f_wr, eight_bytes, 7);
+		if (bytes_written != -1 || errno != EINVAL) {
+			printf("error condition tests FAILED: didn't catch misaligned packet write error (%s)\n",
+				strerror(errno));
+			return -1;
+		}
+	}
+
 	// write packet larger than fifo size
 	unsigned big_buffer_num = 1000000;
 	unsigned big_buffer[big_buffer_num];
@@ -150,39 +172,36 @@ int main(int argc, char *argv[])
 
 	printf("error condition tests PASSED\n");
 
-	// write non word-boundary sized packet
-	int bufSize = 10;
-	uint8_t bufa[bufSize];
-	uint8_t bufb[bufSize];
-	for(int i = 4; i < bufSize; i++) {
-		memset(bufa,0,bufSize);
-		memset(bufb,0,bufSize);
+	uint8_t bufa[MAX_PACKET_SIZE];
+	uint8_t bufb[MAX_PACKET_SIZE];
+	if (tkeep) {
+		for(int i = 4; i < 16; i++) {
+			memset(bufa,0,MAX_PACKET_SIZE);
+			memset(bufb,0,MAX_PACKET_SIZE);
 		for(int j = 0; j < i; j++)
 			bufa[j] = j % 255;
 
 		bytes_written = write(f_wr, bufa, i);
 		bytes_read = read(f_rd, bufb, bytes_written);
 		if(bytes_written != bytes_read){
-			printf("non-word boundary read/write FAILED\n");
+				printf("non-word boundary read/write FAILED : bytes_written != bytes_read\n");
 			return -1;
 		}
 
 		for(int j = 0; j < i; j++) {
 			if (bufa[j] != bufb[j]) {
-				printf("bufa[%d]=0x%x != bufb[%d]=0x%x\n",
+					printf("\tbufa[%d]=0x%x != bufb[%d]=0x%x\n",
 						j,bufa[j],j,bufb[j]);
 				printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
 				return -1;
 			}
 		}
-
 	}
 	printf("non-word boundary read/write test PASSED\n");
+	}
 
 	// test poll subsystem
 	struct pollfd fds[2];
-	int wrote = 0;
-	int done = 0;
 	int pollTimeoutSec = 1;
 	int pollrc;
 	fds[0].fd = f_rd;
@@ -190,78 +209,89 @@ int main(int argc, char *argv[])
 	fds[0].events = POLLIN;
 	fds[1].events = POLLOUT;
 	
-	printf("Running poll test ... will take ~%d seconds\n",4*pollTimeoutSec);
+	printf("running poll test ... will take ~%d seconds\n",4*pollTimeoutSec);
 
-	// test false positive read 
-	while (!done) {
+	/* check false positive read */
+	while (1) {
 		pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
 		if (pollrc < 0) {
-			printf("poll test FAILED : poll returned error ...\n");
+			printf("poll test FAILED : \n");
+			fflush(stdout);
 			perror("poll");
 			return -1;
 		} if (pollrc == 0) {
-			done = 1;
+			printf("\tread false pos pass\n");
+			break;
 		} else {
 			if (fds[0].revents & POLLIN) {
 				printf("poll test FAILED : claimed there was data to read when there was not\n");
 				return -1;
 			} 
-			done = 1;
 		}
 	}
 
-	// test false positive write 
-	// fill up transmit fifo 
-	do {
-		bytes_written = write(f_wr, big_buffer, 128);
-	} while (bytes_written != -1);
-
-	done = 0;
-	while (!done) {
+	/* fill fifo */
+	bytes_written = 0;
+	while (1) {
 		pollrc = poll(&fds[1],1,pollTimeoutSec*1000);
-		if (pollrc < 0) {
-			printf("poll test FAILED : poll returned error ...\n");
-			perror("poll");
-			return -1;
-		} if (pollrc == 0) {
-			done = 1;
-		} else {
+		if (pollrc > 0) {
 			if (fds[1].revents & POLLOUT) {
-				printf("poll test FAILED : claimed there was space to write when there was not\n");
+				rc = write(f_wr, big_buffer, POLL_PACKET_SIZE);
+				if (rc > 0) {
+					bytes_written += rc;
+				} else {
+					printf("poll test FAILED : ");
+					fflush(stdout);
+					perror("write");
 				return -1;
 			} 
-			done = 1;
 		}
+		} else if (pollrc == 0) {
+			printf("\twrite false positive pass\n");
+			break;
+		} else {
+			perror("poll");
+			return -1;
 	}
-	// flush the rx fifo 
-	do {
-		bytes_read = read(f_rd, big_buffer, 128);
-	} while (bytes_read != -1);
+	}
 
-
-	// test functional read/write returns
-	done = 0;
-	while (!done) {
-		pollrc = poll(fds,2,pollTimeoutSec*1000);
+	/* empty out fifo */
+	bytes_read = 0;
+	while (1) {
+		pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
 		if (pollrc < 0) {
-			printf("poll test FAILED : poll returned error ...\n");
+			printf("poll test FAILED : ");
+			fflush(stdout);
 			perror("poll");
 			return -1;
 		} if (pollrc == 0) {
-			printf("poll test FAILED : poll timed out ...\n");
-			return -1;
+			break;
 		} else {
-			if (wrote == 0 && (fds[1].revents & POLLOUT)) {
-				bytes_written = write(f_wr, bufa, bufSize);
-				wrote = 1;
+			if ((fds[0].revents & POLLIN)) {
+				rc = read(f_rd, bufb, POLL_PACKET_SIZE);
+				if (rc >= 0){
+					bytes_read += rc;
+				} else {
+					printf("poll test FAILED : ");
+					fflush(stdout);
+					perror("read");
+					return -1;
 			}
-
-			if (wrote == 1 && (fds[0].revents & POLLIN)) {
-				bytes_read = read(f_rd, bufb, bytes_written);
-				done = 1;
 			}
 		}
 	}
+	if (bytes_written != bytes_read) {
+		printf("\t(bytes_written) %d != (bytes_read) %d\n",
+				bytes_written, bytes_read);
+		printf("\tThis occurs when a packet isnt within the range of the dts values\n"
+				"\trx-min-pkt-size and tx-max-pkt-size ... this test code uses 1024 bytes\n"
+				"\tso rx-min-pkt-size <= 1024/4-1 = 255\n"
+				"\tand tx-max-pkt-size >= 1024/4+1 = 257\n\n");
+		printf("poll test FAILED\n");
+		return -1;
+	}
+	printf("\t(bytes_written) %d == (bytes_read) %d\n",
+				bytes_written, bytes_read);
 	printf("poll test PASSED\n");
 
 	close(f_rd);
@@ -284,7 +314,7 @@ int main(int argc, char *argv[])
 		data_string[i*4 + 3] = (char)r;
 	}
 
-	printf("transferring %i words\n", num_words);
+	printf("\ttransferring %i words\n", num_words);
 
 	struct timespec start_time, stop_time;
 	clock_gettime(CLOCK_MONOTONIC, &start_time);
@@ -385,7 +415,7 @@ int main(int argc, char *argv[])
 				bytes_remaining -= bytes_written;
 				bytes_to_write += bytes_written;
 				write_timeout = time(NULL) + TIMEOUT;
-				printf("\rtransfer %0.1f%% complete      ",
+				printf("\rtransfer %0.1f%% complete	  ",
 					100 * (1 - (float)bytes_remaining /
 					(float)data_string_len));
 			} else if (bytes_written < 0) {


### PR DESCRIPTION
Poll:
Previously was overloading the tx and rx programmable empty values which didn't really belong in poll. Added two new entries to the device tree called `rx-min-pkt-size` and `tx-max-pkt-size` which poll now checks against. Much cleaner. Modified fifo-test.c to test reading/writing from poll with no overflows or underruns.

Tkeep:
Enabled usage of the `has-axis-tkeep` devicetree entry to enable whether or not byte sized writes are supported in the core. When tkeep is enabled (must be both in ip core and device-tree) then byte sized writes are supported; otherwise only word oriented writes are supported. Added runtime option to fifo-test.c to support testing in both configurations. 
