### PR TITLE
Update example code, add more ioctls / sysfs entries, allow sub-word sized transactions

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -Wall -Wextra
 LDFLAGS ?=
 CFLAGS +=
 
-BIN := axis-fifo-test axis-fifo-ethernet-bridge
+BIN := axis-fifo-test axis-fifo-ethernet-bridge axis-fifo-echo-test
 
 all: $(BIN)
 

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,9 +1,9 @@
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -Wall -Wextra
 LDFLAGS ?=
-CFLAGS += 
+CFLAGS +=
 
-BIN := axis-fifo-test axis-fifo-eth-loop
+BIN := axis-fifo-test axis-fifo-ethernet-bridge
 
 all: $(BIN)
 

--- a/apps/axis-fifo-echo-test.c
+++ b/apps/axis-fifo-echo-test.c
@@ -1,0 +1,286 @@
+/**
+ * @file axis-fifo-eth-loop.c
+ * @author Jason Gutel jason.gutel@gmail.com
+ *
+ * Sets up an echo ping-pong server over a TCP connection. Packets are sent
+ * over sockets, sent to the AXI Stream FIFO core (assumed in loopback), and
+ * then sent back out over the socket.
+ *
+ * Shows example of using poll() with the kernel module
+ *
+ * @bug No known bugs.
+ **/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include <fcntl.h>              // Flags for open()
+#include <sys/stat.h>           // Open() system call
+#include <sys/types.h>          // Types for open()
+#include <unistd.h>             // Close() system call
+#include <string.h>             // Memory setting and copying
+#include <getopt.h>             // Option parsing
+#include <errno.h>              // Error codes
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include "../axis-fifo.h"
+
+/*----------------------------------------------------------------------------
+ * Internal Definitions
+ *----------------------------------------------------------------------------*/
+#define DEF_DEV_TX "/dev/axis_fifo_0x43c10000"
+#define DEF_DEV_RX "/dev/axis_fifo_0x43c10000"
+
+#define DEBUG_PRINT(fmt, args...) printf("DEBUG %s:%d(): " fmt, \
+        __func__, __LINE__, ##args)
+
+struct thread_data {
+    int rc;
+};
+
+pthread_t write_to_fifo_thread;
+pthread_t read_from_fifo_thread;
+
+static volatile bool running = true;
+static char _opt_dev_tx[255];
+static char _opt_dev_rx[255];
+static int writeFifoFd;
+static int readFifoFd;
+
+static void signal_handler(int signal);
+static void *read_from_fifo_thread_fn(void *data);
+static int process_options(int argc, char * argv[]);
+static void print_opts();
+static void display_help(char * progName);
+static void *write_to_fifo_thread_fn(void *data);
+static void quit(void);
+
+/*----------------------------------------------------------------------------
+ * Main
+ *----------------------------------------------------------------------------*/
+int main(int argc, char **argv)
+{
+    process_options(argc, argv);
+
+    int rc;
+
+    // Listen to ctrl+c and assert
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+    signal(SIGQUIT, signal_handler);
+
+    /*************/
+    /* open FIFO */
+    /*************/
+    readFifoFd = open(_opt_dev_rx, O_RDONLY | O_NONBLOCK);
+    writeFifoFd = open(_opt_dev_tx, O_WRONLY);
+    if (readFifoFd < 0) {
+        printf("Open read failed with error: %s\n", strerror(errno));
+        return -1;
+    }
+    if (writeFifoFd < 0) {
+        printf("Open write failed with error: %s\n", strerror(errno));
+        return -1;
+    }
+
+    /*****************************/
+    /* initialize the fifo core  */
+    /*****************************/
+    rc = ioctl(readFifoFd, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(writeFifoFd, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+
+    /*****************/
+    /* start threads */
+    /*****************/
+
+    /* start thread listening for ethernet packets */
+    rc = pthread_create(&write_to_fifo_thread, NULL, write_to_fifo_thread_fn,
+            (void *)NULL);
+
+    /* start thread listening for fifo receive packets */
+    rc = pthread_create(&read_from_fifo_thread, NULL, read_from_fifo_thread_fn,
+            (void *)NULL);
+
+    /* perform noops */
+    while (running) {
+       sleep(1);
+    }
+
+ret:
+    printf("SHUTTING DOWN\n");
+    pthread_join(write_to_fifo_thread, NULL);
+    pthread_join(read_from_fifo_thread, NULL);
+    close(writeFifoFd);
+    close(readFifoFd);
+    return rc;
+}
+
+static void quit(void)
+{
+    running = false;
+}
+
+static void *write_to_fifo_thread_fn(void *data)
+{
+    int rc;
+    int packets_rx, packets_tx;
+    char buf[MAX_BUF_SIZE_BYTES];
+    uint32_t vacancy;
+
+    /* shup up compiler */
+    (void)data;
+
+    memset(&cliaddr, 0, sizeof(cliaddr));
+
+    packets_rx = 0;
+    packets_tx = 0;
+
+    while (running) {
+        do {
+            rc = ioctl(writeFifoFd, AXIS_FIFO_GET_TX_VACANCY, &vacancy);
+            if (rc) {
+                perror("ioctl");
+                return (void *)0;
+            }
+            if (vacancy < (uint32_t)MAX_BUF_SIZE_BYTES)
+                usleep(100);
+        } while (vacancy < (uint32_t)MAX_BUF_SIZE_BYTES);
+
+        sscanf(&buf[0],"%s");
+        printf("Sending %s\n\r",buf);
+
+        bytesFifo = write(writeFifoFd, buf, strlen(buf));
+        if (bytesFifo > 0) {
+            DEBUG_PRINT("bytes to fifo %d\n",bytesFifo);
+            packets_tx++;
+        } else {
+            perror("write");
+            quit();
+        }
+    }
+
+    return (void *)0;
+}
+
+static void *read_from_fifo_thread_fn(void *data)
+{
+    ssize_t bytesSock;
+    ssize_t bytesFifo;
+    int packets_rx, packets_tx;
+    uint8_t buf[MAX_BUF_SIZE_BYTES];
+
+    /* shup up compiler */
+    (void)data;
+
+    memset(&cliaddr, 0, sizeof(cliaddr));
+
+    packets_rx = 0;
+    packets_tx = 0;
+
+    while (running) {
+        bytesFifo = read(readFifoFd, buf, MAX_BUF_SIZE_BYTES);
+        if (bytesFifo > 0) {
+            DEBUG_PRINT("bytes from fifo %d\n",bytesFifo);
+            DEBUG_PRINT("Read : %s\n\r",buf);
+            packets_rx++;
+        }
+    }
+
+    return (void *)0;
+}
+
+static void signal_handler(int signal)
+{
+    switch (signal) {
+        case SIGINT:
+        case SIGTERM:
+        case SIGQUIT:
+            running = false;
+            break;
+
+        default:
+            break;
+    }
+}
+
+static void display_help(char * progName)
+{
+    printf("Usage : %s [OPTIONS]\n"
+           "\n"
+           "  -h, --help     Print this menu\n"
+           "  -t, --devTx    Device to use ... /dev/axis_fifo_0x43c10000\n"
+           "  -r, --devRx    Device to use ... /dev/axis_fifo_0x43c10000\n"
+           ,
+           progName
+          );
+}
+
+static void print_opts()
+{
+    printf("Options : \n"
+            "DevTX          : %s\n"
+            "DevRx          : %s\n"
+           ,
+           _opt_dev_tx,
+           _opt_dev_rx
+          );
+}
+
+static int process_options(int argc, char * argv[])
+{
+        strcpy(_opt_dev_tx,DEF_DEV_TX);
+        strcpy(_opt_dev_rx,DEF_DEV_RX);
+
+        for (;;) {
+            int option_index = 0;
+            static const char *short_options = "hr:t:";
+            static const struct option long_options[] = {
+                    {"help", no_argument, 0, 'h'},
+                    {"devRx", required_argument, 0, 'r'},
+                    {"devTx", required_argument, 0, 't'},
+                    {0,0,0,0},
+                    };
+
+            int c = getopt_long(argc, argv, short_options,
+            long_options, &option_index);
+
+            if (c == EOF) {
+            break;
+            }
+
+            switch (c) {
+                case 't':
+                    strcpy(_opt_dev_tx, optarg);
+                    break;
+
+                case 'r':
+                    strcpy(_opt_dev_rx, optarg);
+                    break;
+
+                default:
+                case 'h':
+                    display_help(argv[0]);
+                    exit(0);
+                    break;
+                    }
+            }
+
+        print_opts();
+        return 0;
+}

--- a/apps/axis-fifo-echo-test.c
+++ b/apps/axis-fifo-echo-test.c
@@ -1,12 +1,10 @@
 /**
- * @file axis-fifo-eth-loop.c
+ * @file axis-fifo-echo-test.c
  * @author Jason Gutel jason.gutel@gmail.com
  *
- * Sets up an echo ping-pong server over a TCP connection. Packets are sent
- * over sockets, sent to the AXI Stream FIFO core (assumed in loopback), and
- * then sent back out over the socket.
- *
- * Shows example of using poll() with the kernel module
+ * Simple test app that will prompt user to send an ASCII
+ * string to the tx fifo in one thread and print everything
+ * that shows up on the rx fifo. Useful for debugging.
  *
  * @bug No known bugs.
  **/

--- a/apps/axis-fifo-ethernet-bridge.c
+++ b/apps/axis-fifo-ethernet-bridge.c
@@ -1,12 +1,13 @@
 /**
- * @file axis-fifo-eth-loop.c
+ * @file axis-fifo-ethernet-bridge.c
  * @author Jason Gutel jason.gutel@gmail.com
  *
- * Sets up an echo ping-pong server over a TCP connection. Packets are sent
- * over sockets, sent to the AXI Stream FIFO core (assumed in loopback), and
- * then sent back out over the socket.
- *
- * Shows example of using poll() with the kernel module
+ * Sets up a bridge between a TCP|UDP socket and the axis fifo
+ * driver. Packets received from the socket will be sent to
+ * the associated TX FIFO. Packets received form the RX FIFO
+ * will be sent back out over the socket. For UDP the socket
+ * needs to be initialized so that the partner IPv4 address
+ * is known.
  *
  * @bug No known bugs.
  **/

--- a/apps/axis-fifo-ethernet-bridge.c
+++ b/apps/axis-fifo-ethernet-bridge.c
@@ -353,7 +353,12 @@ static void display_help(char * progName)
            "  -t, --devTx    Device to use ... /dev/axis_fifo_0x43c10000\n"
            "  -r, --devRx    Device to use ... /dev/axis_fifo_0x43c10000\n"
            "  -p, --port     Port number to bind to\n"
-           "  -x, --tcp      udp used by default, pass this flag to use tcp\n"
+           "  -x, --tcp      udp used by default, pass this flag to use tcp\n\n"
+           " Creates a UDP (or TCP) server that waits for data passed to the port\n"
+           " and then forwards the data to the attached transmit axis fifo device.\n"
+           " Data incoming from the receive axis fifo is pushed back to the client's\n"
+           " IP Address and same port.\n"
+           " When using UDP no data will be sent to client until a message is received.\n"
            ,
            progName
           );

--- a/apps/axis-fifo-test.c
+++ b/apps/axis-fifo-test.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <poll.h>
+#include <sys/ioctl.h>
 #include "../axis-fifo.h"
 
 /*
@@ -34,510 +35,510 @@ pass in the number of words to write and the driver device file location(s)
 
 int main(int argc, char *argv[])
 {
-	if (argc < 4 || argc > 5) {
-		printf("usage: %s [# words] [tkeep] [read device file] [optional: write device file]\n", argv[0]);
-		printf("		e.g. \"%s 1024 1 /dev/axis_fifo0\" for loopback configuration\n", argv[0]);
-		printf("		e.g. \"%s 1024 1 /dev/axis_fifo0 /dev/axis_fifo1\" for passthrough configuration\n", argv[0]);
-		return -1;
-	}
+    if (argc < 4 || argc > 5) {
+        printf("usage: %s [# words] [tkeep] [read device file] [optional: write device file]\n", argv[0]);
+        printf("        e.g. \"%s 1024 1 /dev/axis_fifo0\" for loopback configuration\n", argv[0]);
+        printf("        e.g. \"%s 1024 1 /dev/axis_fifo0 /dev/axis_fifo1\" for passthrough configuration\n", argv[0]);
+        return -1;
+    }
 
-	// transmitted data string
-	char *data_string;
-	unsigned data_string_len;
-	int rc;
+    // transmitted data string
+    char *data_string;
+    unsigned data_string_len;
+    int rc;
 
-	// device file locations
-	char *read_device_file;
-	char *write_device_file;
+    // device file locations
+    char *read_device_file;
+    char *write_device_file;
 
-	ssize_t bytes_written;
-	ssize_t bytes_read;
-	// file descriptors
-	int f_rd;
-	int f_wr;
-	int tkeep;
+    ssize_t bytes_written;
+    ssize_t bytes_read;
+    // file descriptors
+    int f_rd;
+    int f_wr;
+    int tkeep;
 
-	// first argument is how many words to write
-	unsigned num_words = atoi(argv[1]);
-	data_string_len = num_words*4;
+    // first argument is how many words to write
+    unsigned num_words = atoi(argv[1]);
+    data_string_len = num_words*4;
 
-	printf("START :\n\n");
+    printf("START :\n\n");
 
-	tkeep = atoi(argv[2]);
-	if (!!tkeep)
-		printf("TKEEP enabled ... testing byte boundary read/writes\n");
-	else
-		printf("TKEEP not enabled ... testing word boundary read/writes\n");
+    tkeep = atoi(argv[2]);
+    if (!!tkeep)
+        printf("TKEEP enabled ... testing byte boundary read/writes\n");
+    else
+        printf("TKEEP not enabled ... testing word boundary read/writes\n");
 
-	// second / third arguments are read/write device file names
-	if (argc == 4) {
-		read_device_file = argv[3];
-		write_device_file = argv[3];
-	} else {
-		read_device_file = argv[3];
-		write_device_file = argv[4];
-	}
+    // second / third arguments are read/write device file names
+    if (argc == 4) {
+        read_device_file = argv[3];
+        write_device_file = argv[3];
+    } else {
+        read_device_file = argv[3];
+        write_device_file = argv[4];
+    }
 
-	f_rd = open(read_device_file, O_RDONLY);
-	f_wr = open(write_device_file, O_WRONLY);
+    f_rd = open(read_device_file, O_RDONLY);
+    f_wr = open(write_device_file, O_WRONLY);
 
-	// test error conditions
-	if (f_rd < 0) {
-		printf("Open read failed with error: %s\n", strerror(errno));
-		return -1;
-	}
-	if (f_wr < 0) {
-		printf("Open write failed with error: %s\n", strerror(errno));
-		return -1;
-	}
+    // test error conditions
+    if (f_rd < 0) {
+        printf("Open read failed with error: %s\n", strerror(errno));
+        return -1;
+    }
+    if (f_wr < 0) {
+        printf("Open write failed with error: %s\n", strerror(errno));
+        return -1;
+    }
 
-	unsigned eight_bytes[2] = {0xDEADBEEF, 0xDEADBEEF};
+    unsigned eight_bytes[2] = {0xDEADBEEF, 0xDEADBEEF};
 
-	printf("\nTESTING error conditions...\n");
-	fflush(stdout);
+    printf("\nTESTING error conditions...\n");
+    fflush(stdout);
 
-	// read buffer too small test
-	bytes_written = write(f_wr, eight_bytes, 8);
-	if (bytes_written != 8) {
-		if (bytes_written == -1) {
-			printf("error condition tests FAILED: write failed with code %s\n",
-				strerror(errno));
-		} else {
-			printf("error condition tests FAILED: write failed - only wrote %i bytes\n",
-				bytes_written);
-		}
-		return -1;
-	}
-	bytes_read = read(f_rd, NULL, 4);
-	if (bytes_read != -1 || errno != EINVAL) {
-		printf("error condition tests FAILED: didn't catch read buffer too small error (errno=%i)\n",
-			errno);
-		return -1;
-	}
+    // read buffer too small test
+    bytes_written = write(f_wr, eight_bytes, 8);
+    if (bytes_written != 8) {
+        if (bytes_written == -1) {
+            printf("error condition tests FAILED: write failed with code %s\n",
+                strerror(errno));
+        } else {
+            printf("error condition tests FAILED: write failed - only wrote %i bytes\n",
+                bytes_written);
+        }
+        return -1;
+    }
+    bytes_read = read(f_rd, NULL, 4);
+    if (bytes_read != -1 || errno != EINVAL) {
+        printf("error condition tests FAILED: didn't catch read buffer too small error (errno=%i)\n",
+            errno);
+        return -1;
+    }
 
-	// userland read pointer error test
-	bytes_written = write(f_wr, eight_bytes, 8);
-	if (bytes_written != 8) {
-		if (bytes_written == -1) {
-			printf("error condition tests FAILED: write failed with code %s\n",
-				strerror(errno));
-		} else {
-			printf("error condition tests FAILED: write failed - only wrote %i bytes\n",
-				bytes_written);
-		}
-		return -1;
-	}
-	bytes_read = read(f_rd, NULL, 8);
-	if (bytes_read != -1 || errno != EFAULT) {
-		printf("error condition tests FAILED: didn't catch userland read pointer error (%s)\n",
-			strerror(errno));
-		return -1;
-	}
+    // userland read pointer error test
+    bytes_written = write(f_wr, eight_bytes, 8);
+    if (bytes_written != 8) {
+        if (bytes_written == -1) {
+            printf("error condition tests FAILED: write failed with code %s\n",
+                strerror(errno));
+        } else {
+            printf("error condition tests FAILED: write failed - only wrote %i bytes\n",
+                bytes_written);
+        }
+        return -1;
+    }
+    bytes_read = read(f_rd, NULL, 8);
+    if (bytes_read != -1 || errno != EFAULT) {
+        printf("error condition tests FAILED: didn't catch userland read pointer error (%s)\n",
+            strerror(errno));
+        return -1;
+    }
 
-	// userland write pointer error test
-	bytes_written = write(f_wr, NULL, 8);
-	if (bytes_written != -1 || errno != EFAULT) {
-		printf("error condition tests FAILED: didn't catch userland write pointer error (%s)\n",
-			strerror(errno));
-		return -1;
-	}
+    // userland write pointer error test
+    bytes_written = write(f_wr, NULL, 8);
+    if (bytes_written != -1 || errno != EFAULT) {
+        printf("error condition tests FAILED: didn't catch userland write pointer error (%s)\n",
+            strerror(errno));
+        return -1;
+    }
 
-	// write 0-length packet
-	bytes_written = write(f_wr, eight_bytes, 0);
-	if (bytes_written != -1 || errno != EINVAL) {
-		printf("error condition tests FAILED: didn't catch 0-length packet write error (%s)\n",
-			strerror(errno));
-		return -1;
-	}
+    // write 0-length packet
+    bytes_written = write(f_wr, eight_bytes, 0);
+    if (bytes_written != -1 || errno != EINVAL) {
+        printf("error condition tests FAILED: didn't catch 0-length packet write error (%s)\n",
+            strerror(errno));
+        return -1;
+    }
 
-	if (!tkeep) {
-		// write misaligned packet
-		// this will only fail if TKEEP is NOT enabled
-		bytes_written = write(f_wr, eight_bytes, 7);
-		if (bytes_written != -1 || errno != EINVAL) {
-			printf("error condition tests FAILED: didn't catch misaligned packet write error (%s)\n",
-				strerror(errno));
-			return -1;
-		}
-	}
+    if (!tkeep) {
+        // write misaligned packet
+        // this will only fail if TKEEP is NOT enabled
+        bytes_written = write(f_wr, eight_bytes, 7);
+        if (bytes_written != -1 || errno != EINVAL) {
+            printf("error condition tests FAILED: didn't catch misaligned packet write error (%s)\n",
+                strerror(errno));
+            return -1;
+        }
+    }
 
-	printf("Reseting with ioctl...\n");
-	rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
+    printf("Reseting with ioctl...\n");
+    rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
 
-	// write packet larger than fifo size
-	unsigned big_buffer_num = 1000000;
-	unsigned big_buffer[big_buffer_num];
-	bytes_written = write(f_wr, big_buffer, big_buffer_num*4);
-	if (bytes_written != -1 || errno != EINVAL) {
-		printf("error condition tests FAILED: didn't catch oversized packet write error (%s)\n",
-			strerror(errno));
-		return -1;
-	}
+    // write packet larger than fifo size
+    unsigned big_buffer_num = 1000000;
+    unsigned big_buffer[big_buffer_num];
+    bytes_written = write(f_wr, big_buffer, big_buffer_num*4);
+    if (bytes_written != -1 || errno != EINVAL) {
+        printf("error condition tests FAILED: didn't catch oversized packet write error (%s)\n",
+            strerror(errno));
+        return -1;
+    }
 
-	printf("error condition tests PASSED\n");
+    printf("error condition tests PASSED\n");
 
-	uint8_t bufa[MAX_PACKET_SIZE];
-	uint8_t bufb[MAX_PACKET_SIZE];
-	if (tkeep) {
-		for(int i = 4; i < 16; i++) {
-			memset(bufa,0,MAX_PACKET_SIZE);
-			memset(bufb,0,MAX_PACKET_SIZE);
-			for(int j = 0; j < i; j++)
-				bufa[j] = j % 255;
+    uint8_t bufa[MAX_PACKET_SIZE];
+    uint8_t bufb[MAX_PACKET_SIZE];
+    if (tkeep) {
+        for(int i = 4; i < 16; i++) {
+            memset(bufa,0,MAX_PACKET_SIZE);
+            memset(bufb,0,MAX_PACKET_SIZE);
+            for(int j = 0; j < i; j++)
+                bufa[j] = j % 255;
 
-			bytes_written = write(f_wr, bufa, i);
-			bytes_read = read(f_rd, bufb, bytes_written);
-			if(bytes_written != bytes_read){
-				printf("non-word boundary read/write FAILED : bytes_written != bytes_read\n");
-				return -1;
-			}
+            bytes_written = write(f_wr, bufa, i);
+            bytes_read = read(f_rd, bufb, bytes_written);
+            if(bytes_written != bytes_read){
+                printf("non-word boundary read/write FAILED : bytes_written != bytes_read\n");
+                return -1;
+            }
 
-			for(int j = 0; j < i; j++) {
-				if (bufa[j] != bufb[j]) {
-					printf("\tbufa[%d]=0x%x != bufb[%d]=0x%x\n",
-						j,bufa[j],j,bufb[j]);
-					printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
-					return -1;
-				}
-			}
-		}
-		printf("non-word boundary read/write test PASSED\n");
-	}
+            for(int j = 0; j < i; j++) {
+                if (bufa[j] != bufb[j]) {
+                    printf("\tbufa[%d]=0x%x != bufb[%d]=0x%x\n",
+                        j,bufa[j],j,bufb[j]);
+                    printf("non-word boundary read/write FAILED : with bytes size = %d ...\n",i);
+                    return -1;
+                }
+            }
+        }
+        printf("non-word boundary read/write test PASSED\n");
+    }
 
-	// test poll subsystem
-	struct pollfd fds[2];
-	int pollTimeoutSec = 1;
-	int pollrc;
-	uint32_t minPktBak;
-	uint32_t maxPktBak;
-	fds[0].fd = f_rd;
-	fds[1].fd = f_wr;
-	fds[0].events = POLLIN;
-	fds[1].events = POLLOUT;
-	uint32_t minPkt = 255;
-	uint32_t maxPkt = 257;
+    // test poll subsystem
+    struct pollfd fds[2];
+    int pollTimeoutSec = 1;
+    int pollrc;
+    uint32_t minPktBak;
+    uint32_t maxPktBak;
+    fds[0].fd = f_rd;
+    fds[1].fd = f_wr;
+    fds[0].events = POLLIN;
+    fds[1].events = POLLOUT;
+    uint32_t minPkt = 255;
+    uint32_t maxPkt = 257;
 
-	/* initializing rx-min-pkt-size and tx-max-pkt-size */
-	/* back up curent values */
-	rc = ioctl(f_rd, AXIS_FIFO_GET_RX_MIN_PKT, &minPktBak);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_GET_TX_MAX_PKT, &maxPktBak);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	/* update values for this test */
-	rc = ioctl(f_rd, AXIS_FIFO_SET_RX_MIN_PKT, &minPkt);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_SET_TX_MAX_PKT, &maxPkt);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	/* reset core */
-	rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	printf("running poll test ... will take ~%d seconds\n",4*pollTimeoutSec);
+    /* initializing rx-min-pkt-size and tx-max-pkt-size */
+    /* back up curent values */
+    rc = ioctl(f_rd, AXIS_FIFO_GET_RX_MIN_PKT, &minPktBak);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_GET_TX_MAX_PKT, &maxPktBak);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    /* update values for this test */
+    rc = ioctl(f_rd, AXIS_FIFO_SET_RX_MIN_PKT, &minPkt);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_SET_TX_MAX_PKT, &maxPkt);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    /* reset core */
+    rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    printf("running poll test ... will take ~%d seconds\n",4*pollTimeoutSec);
 
-	/* check false positive read */
-	while (1) {
-		pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
-		if (pollrc < 0) {
-			printf("poll test FAILED : \n");
-			fflush(stdout);
-			perror("poll");
-			return -1;
-		} if (pollrc == 0) {
-			printf("\tread false pos pass\n");
-			break;
-		} else {
-			if (fds[0].revents & POLLIN) {
-				printf("poll test FAILED : claimed there was data to read when there was not\n");
-				return -1;
-			} 
-		}
-	}
+    /* check false positive read */
+    while (1) {
+        pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
+        if (pollrc < 0) {
+            printf("poll test FAILED : \n");
+            fflush(stdout);
+            perror("poll");
+            return -1;
+        } if (pollrc == 0) {
+            printf("\tread false pos pass\n");
+            break;
+        } else {
+            if (fds[0].revents & POLLIN) {
+                printf("poll test FAILED : claimed there was data to read when there was not\n");
+                return -1;
+            }
+        }
+    }
 
-	/* fill fifo */
-	bytes_written = 0;
-	while (1) {
-		pollrc = poll(&fds[1],1,pollTimeoutSec*1000);
-		if (pollrc > 0) {
-			if (fds[1].revents & POLLOUT) {
-				rc = write(f_wr, big_buffer, POLL_PACKET_SIZE);
-				if (rc > 0) {
-					bytes_written += rc;
-				} else {
-					printf("poll test FAILED : ");
-					fflush(stdout);
-					perror("write");
-				return -1;
-				} 
-			}
-		} else if (pollrc == 0) {
-			printf("\twrite false positive pass\n");
-			break;
-		} else {
-			perror("poll");
-			return -1;
-		}
-	}
+    /* fill fifo */
+    bytes_written = 0;
+    while (1) {
+        pollrc = poll(&fds[1],1,pollTimeoutSec*1000);
+        if (pollrc > 0) {
+            if (fds[1].revents & POLLOUT) {
+                rc = write(f_wr, big_buffer, POLL_PACKET_SIZE);
+                if (rc > 0) {
+                    bytes_written += rc;
+                } else {
+                    printf("poll test FAILED : ");
+                    fflush(stdout);
+                    perror("write");
+                return -1;
+                }
+            }
+        } else if (pollrc == 0) {
+            printf("\twrite false positive pass\n");
+            break;
+        } else {
+            perror("poll");
+            return -1;
+        }
+    }
 
-	/* empty out fifo */
-	bytes_read = 0;
-	while (1) {
-		pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
-		if (pollrc < 0) {
-			printf("poll test FAILED : ");
-			fflush(stdout);
-			perror("poll");
-			return -1;
-		} if (pollrc == 0) {
-			break;
-		} else {
-			if ((fds[0].revents & POLLIN)) {
-				rc = read(f_rd, bufb, POLL_PACKET_SIZE);
-				if (rc >= 0){
-					bytes_read += rc;
-				} else {
-					printf("poll test FAILED : ");
-					fflush(stdout);
-					perror("read");
-					return -1;
-				}
-			}
-		}
-	}
-	if (bytes_written != bytes_read) {
-		printf("\t(bytes_written) %d != (bytes_read) %d\n",
-				bytes_written, bytes_read);
-		printf("\tThis occurs when a packet isnt within the range of the dts values\n"
-				"\trx-min-pkt-size and tx-max-pkt-size ... this test code uses 1024 bytes\n"
-				"\tso rx-min-pkt-size <= 1024/4-1 = 255\n"
-				"\tand tx-max-pkt-size >= 1024/4+1 = 257\n\n");
-		printf("poll test FAILED\n");
-		return -1;
-	}
-	printf("\t(bytes_written) %d == (bytes_read) %d\n",
-				bytes_written, bytes_read);
-	printf("poll test PASSED\n");
+    /* empty out fifo */
+    bytes_read = 0;
+    while (1) {
+        pollrc = poll(&fds[0],1,pollTimeoutSec*1000);
+        if (pollrc < 0) {
+            printf("poll test FAILED : ");
+            fflush(stdout);
+            perror("poll");
+            return -1;
+        } if (pollrc == 0) {
+            break;
+        } else {
+            if ((fds[0].revents & POLLIN)) {
+                rc = read(f_rd, bufb, POLL_PACKET_SIZE);
+                if (rc >= 0){
+                    bytes_read += rc;
+                } else {
+                    printf("poll test FAILED : ");
+                    fflush(stdout);
+                    perror("read");
+                    return -1;
+                }
+            }
+        }
+    }
+    if (bytes_written != bytes_read) {
+        printf("\t(bytes_written) %d != (bytes_read) %d\n",
+                bytes_written, bytes_read);
+        printf("\tThis occurs when a packet isnt within the range of the dts values\n"
+                "\trx-min-pkt-size and tx-max-pkt-size ... this test code uses 1024 bytes\n"
+                "\tso rx-min-pkt-size <= 1024/4-1 = 255\n"
+                "\tand tx-max-pkt-size >= 1024/4+1 = 257\n\n");
+        printf("poll test FAILED\n");
+        return -1;
+    }
+    printf("\t(bytes_written) %d == (bytes_read) %d\n",
+                bytes_written, bytes_read);
+    printf("poll test PASSED\n");
 
 
-	/* restore original min/max pkt sizes */
-	rc = ioctl(f_rd, AXIS_FIFO_SET_RX_MIN_PKT, &minPktBak);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_SET_TX_MAX_PKT, &maxPktBak);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	/* reset cores */
-	rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
-	rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
-	if (rc) {
-		perror("ioctl");
-		return -1;
-	}
+    /* restore original min/max pkt sizes */
+    rc = ioctl(f_rd, AXIS_FIFO_SET_RX_MIN_PKT, &minPktBak);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_SET_TX_MAX_PKT, &maxPktBak);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    /* reset cores */
+    rc = ioctl(f_rd, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
+    rc = ioctl(f_wr, AXIS_FIFO_RESET_IP);
+    if (rc) {
+        perror("ioctl");
+        return -1;
+    }
 
-	close(f_rd);
-	close(f_wr);
+    close(f_rd);
+    close(f_wr);
 
-	data_string = (char *)malloc(data_string_len);
+    data_string = (char *)malloc(data_string_len);
 
-	// seed random number generator
-	srand(time(NULL));
+    // seed random number generator
+    srand(time(NULL));
 
-	printf("generating byte stream...\n");
+    printf("generating byte stream...\n");
 
-	// generate random string of numbers
-	// e.g. 3 words 111155558888
-	for (unsigned i = 0; i < num_words; i++) {
-		unsigned r = rand() % 10 + '0';
-		data_string[i*4 + 0] = (char)r;
-		data_string[i*4 + 1] = (char)r;
-		data_string[i*4 + 2] = (char)r;
-		data_string[i*4 + 3] = (char)r;
-	}
+    // generate random string of numbers
+    // e.g. 3 words 111155558888
+    for (unsigned i = 0; i < num_words; i++) {
+        unsigned r = rand() % 10 + '0';
+        data_string[i*4 + 0] = (char)r;
+        data_string[i*4 + 1] = (char)r;
+        data_string[i*4 + 2] = (char)r;
+        data_string[i*4 + 3] = (char)r;
+    }
 
-	printf("\ttransferring %i words\n", num_words);
+    printf("\ttransferring %i words\n", num_words);
 
-	struct timespec start_time, stop_time;
-	clock_gettime(CLOCK_MONOTONIC, &start_time);
+    struct timespec start_time, stop_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
 
-	// fork into a reader/writer process
-	pid_t pid = fork();
-	if (pid == -1) {
-		printf("fork failed: %s\n", strerror(errno));
-		free(data_string);
-		return EXIT_FAILURE;
-	}
-	else if (pid == 0) {
-		// reader (child) process
+    // fork into a reader/writer process
+    pid_t pid = fork();
+    if (pid == -1) {
+        printf("fork failed: %s\n", strerror(errno));
+        free(data_string);
+        return EXIT_FAILURE;
+    }
+    else if (pid == 0) {
+        // reader (child) process
 
-		int f = open(read_device_file, O_RDONLY);
+        int f = open(read_device_file, O_RDONLY);
 
-		if (f < 0) {
-			printf("read open failed with code '%s'\n", 
-				strerror(errno));
-			free(data_string);
-			_exit(EXIT_FAILURE);
-		}
+        if (f < 0) {
+            printf("read open failed with code '%s'\n",
+                strerror(errno));
+            free(data_string);
+            _exit(EXIT_FAILURE);
+        }
 
-		time_t read_timeout = time(NULL) + TIMEOUT;
+        time_t read_timeout = time(NULL) + TIMEOUT;
 
-		// read buffer
-		char *read_data = (char *)malloc(MAX_PACKET_SIZE);
+        // read buffer
+        char *read_data = (char *)malloc(MAX_PACKET_SIZE);
 
-		unsigned read_offset = 0;
-		unsigned bytes_remaining = data_string_len;
-		while (bytes_remaining) {
+        unsigned read_offset = 0;
+        unsigned bytes_remaining = data_string_len;
+        while (bytes_remaining) {
 
-			// read from device until we get all
-			// the bytes sent or a timeout occurs
-			bytes_read = read(f, read_data, bytes_remaining);
-			if (bytes_read > 0) {
-				if (memcmp(read_data, data_string + read_offset,
-						bytes_read) != 0) {
-					printf("\nread failed - data corruption\n");
-					close(f);
-					free(data_string);
-					free(read_data);
-					_exit(EXIT_FAILURE);
-				}
-				bytes_remaining -= bytes_read;
-				read_offset += bytes_read;
-				read_timeout = time(NULL) + TIMEOUT;
-			} else if (bytes_read < 0) {
-				// read error
-				printf("\nread failed with code '%s'\n",
-					strerror(errno));
-				close(f);
-				free(data_string);
-				free(read_data);
-				_exit(EXIT_FAILURE);
-			}
+            // read from device until we get all
+            // the bytes sent or a timeout occurs
+            bytes_read = read(f, read_data, bytes_remaining);
+            if (bytes_read > 0) {
+                if (memcmp(read_data, data_string + read_offset,
+                        bytes_read) != 0) {
+                    printf("\nread failed - data corruption\n");
+                    close(f);
+                    free(data_string);
+                    free(read_data);
+                    _exit(EXIT_FAILURE);
+                }
+                bytes_remaining -= bytes_read;
+                read_offset += bytes_read;
+                read_timeout = time(NULL) + TIMEOUT;
+            } else if (bytes_read < 0) {
+                // read error
+                printf("\nread failed with code '%s'\n",
+                    strerror(errno));
+                close(f);
+                free(data_string);
+                free(read_data);
+                _exit(EXIT_FAILURE);
+            }
 
-			if (time(NULL) > read_timeout) {
-				// timeout
-				printf("\nread timed out\n");
-				close(f);
-				free(data_string);
-				free(read_data);
-				_exit(EXIT_FAILURE);
-			}
-		}
+            if (time(NULL) > read_timeout) {
+                // timeout
+                printf("\nread timed out\n");
+                close(f);
+                free(data_string);
+                free(read_data);
+                _exit(EXIT_FAILURE);
+            }
+        }
 
-		// success
-		close(f);
-	}
-	else {
-		// writer process
+        // success
+        close(f);
+    }
+    else {
+        // writer process
 
-		int f = open(write_device_file, O_WRONLY);
+        int f = open(write_device_file, O_WRONLY);
 
-		if (f < 0) {
-			printf("write open failed with code '%s'\n",
-				strerror(errno));
-			free(data_string);
-			return EXIT_FAILURE;
-		}
+        if (f < 0) {
+            printf("write open failed with code '%s'\n",
+                strerror(errno));
+            free(data_string);
+            return EXIT_FAILURE;
+        }
 
-		time_t write_timeout = time(NULL) + TIMEOUT;
+        time_t write_timeout = time(NULL) + TIMEOUT;
 
-		// write data_string to file
-		unsigned bytes_remaining = data_string_len;
-		char *bytes_to_write = data_string;
+        // write data_string to file
+        unsigned bytes_remaining = data_string_len;
+        char *bytes_to_write = data_string;
 
-		unsigned write_packet_size;
-		while (bytes_remaining) {
+        unsigned write_packet_size;
+        while (bytes_remaining) {
 
-			write_packet_size = MAX_PACKET_SIZE;
-			bytes_written = write(f, bytes_to_write,
-					bytes_remaining > write_packet_size ?
-					write_packet_size :
-					bytes_remaining);
-			if (bytes_written > 0) {
-				bytes_remaining -= bytes_written;
-				bytes_to_write += bytes_written;
-				write_timeout = time(NULL) + TIMEOUT;
-				printf("\rtransfer %0.1f%% complete	  ",
-					100 * (1 - (float)bytes_remaining /
-					(float)data_string_len));
-			} else if (bytes_written < 0) {
-				printf("\nwrite failed with code '%s' " \
-					"write_packet_size=%i\n",
-					strerror(errno), write_packet_size);
-				close(f);
-				break;
-			} else if (time(NULL) > write_timeout) {
-				// timeout
-				printf("\nwrite timed out\n");
-				close(f);
-				break;
-			}
-		}
+            write_packet_size = MAX_PACKET_SIZE;
+            bytes_written = write(f, bytes_to_write,
+                    bytes_remaining > write_packet_size ?
+                    write_packet_size :
+                    bytes_remaining);
+            if (bytes_written > 0) {
+                bytes_remaining -= bytes_written;
+                bytes_to_write += bytes_written;
+                write_timeout = time(NULL) + TIMEOUT;
+                printf("\rtransfer %0.1f%% complete   ",
+                    100 * (1 - (float)bytes_remaining /
+                    (float)data_string_len));
+            } else if (bytes_written < 0) {
+                printf("\nwrite failed with code '%s' " \
+                    "write_packet_size=%i\n",
+                    strerror(errno), write_packet_size);
+                close(f);
+                break;
+            } else if (time(NULL) > write_timeout) {
+                // timeout
+                printf("\nwrite timed out\n");
+                close(f);
+                break;
+            }
+        }
 
-		printf("\n");
+        printf("\n");
 
-		// wait for child process to complete and collect return status
-		int status;
-		(void)waitpid(pid, &status, 0);
+        // wait for child process to complete and collect return status
+        int status;
+        (void)waitpid(pid, &status, 0);
 
-		clock_gettime(CLOCK_MONOTONIC, &stop_time);
-		float runtime = (float)(stop_time.tv_sec - start_time.tv_sec) +
-				(float)(stop_time.tv_nsec - start_time.tv_nsec)
-				/ 1000000000.0;
+        clock_gettime(CLOCK_MONOTONIC, &stop_time);
+        float runtime = (float)(stop_time.tv_sec - start_time.tv_sec) +
+                (float)(stop_time.tv_nsec - start_time.tv_nsec)
+                / 1000000000.0;
 
-		if (WIFEXITED(status)) {
-			// exited normally
-			if (WEXITSTATUS(status) == EXIT_SUCCESS) {
-				printf("transfer succeeded after %.3f seconds\n",
-					runtime);
-				printf("transfer speed %.3fMB/s\n",
-					(float)data_string_len / runtime /
-					1024.0 / 1024.0);
-			} else {
-				printf("transfer failed after %.3f seconds\n",
-					runtime);
-			}
-		} else {
-			printf("transfer failed after %.3f seconds\n",
-				runtime);
-		}
+        if (WIFEXITED(status)) {
+            // exited normally
+            if (WEXITSTATUS(status) == EXIT_SUCCESS) {
+                printf("transfer succeeded after %.3f seconds\n",
+                    runtime);
+                printf("transfer speed %.3fMB/s\n",
+                    (float)data_string_len / runtime /
+                    1024.0 / 1024.0);
+            } else {
+                printf("transfer failed after %.3f seconds\n",
+                    runtime);
+            }
+        } else {
+            printf("transfer failed after %.3f seconds\n",
+                runtime);
+        }
 
-		close(f);
-		free(data_string);
-	}
+        close(f);
+        free(data_string);
+    }
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -369,6 +369,16 @@ static const struct attribute_group axis_fifo_attrs_group = {
  * ----------------------------
  */
 
+static void reset_tx(struct axis_fifo *fifo)
+{
+    iowrite32(XLLF_TDFR_RESET_MASK, fifo->base_addr + XLLF_TDFR_OFFSET);
+}
+
+static void reset_rx(struct axis_fifo *fifo)
+{
+    iowrite32(XLLF_RDFR_RESET_MASK, fifo->base_addr + XLLF_RDFR_OFFSET);
+}
+
 static void reset_ip_core(struct axis_fifo *fifo)
 {
     iowrite32(XLLF_SRR_RESET_MASK, fifo->base_addr + XLLF_SRR_OFFSET);
@@ -842,28 +852,32 @@ static irqreturn_t axis_fifo_irq(int irq, void *dw)
         } else if (pending_interrupts & XLLF_INT_RPURE_MASK) {
             /* receive fifo under-read error interrupt */
             dev_err(fifo->dt_device,
-                "receive under-read interrupt\n");
+                "receive under-read interrupt, reset rx fifo\n");
+            reset_rx(fifo);
 
             iowrite32(XLLF_INT_RPURE_MASK & XLLF_INT_ALL_MASK,
                   fifo->base_addr + XLLF_ISR_OFFSET);
         } else if (pending_interrupts & XLLF_INT_RPORE_MASK) {
             /* receive over-read error interrupt */
             dev_err(fifo->dt_device,
-                "receive over-read interrupt\n");
+                "receive over-read interrupt, reset rx fifo\n");
+                reset_rx(fifo);
 
             iowrite32(XLLF_INT_RPORE_MASK & XLLF_INT_ALL_MASK,
                   fifo->base_addr + XLLF_ISR_OFFSET);
         } else if (pending_interrupts & XLLF_INT_RPUE_MASK) {
             /* receive underrun error interrupt */
             dev_err(fifo->dt_device,
-                "receive underrun error interrupt\n");
+                "receive underrun error interrupt, reset rx fifo\n");
+            reset_rx(fifo);
 
             iowrite32(XLLF_INT_RPUE_MASK & XLLF_INT_ALL_MASK,
                   fifo->base_addr + XLLF_ISR_OFFSET);
         } else if (pending_interrupts & XLLF_INT_TPOE_MASK) {
             /* transmit overrun error interrupt */
             dev_err(fifo->dt_device,
-                "transmit overrun error interrupt\n");
+                "transmit overrun error interrupt, reset tx fifo\n");
+            reset_tx(fifo);
 
             iowrite32(XLLF_INT_TPOE_MASK & XLLF_INT_ALL_MASK,
                   fifo->base_addr + XLLF_ISR_OFFSET);

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -76,34 +76,34 @@ MODULE_PARM_DESC(write_timeout, "ms to wait before blocking write() timing out; 
  */
 
 struct axis_fifo {
-	int irq; /* interrupt */
-	struct resource *mem; /* physical memory */
-	void __iomem *base_addr; /* kernel space memory */
-	uint32_t fpga_addr;
+    int irq; /* interrupt */
+    struct resource *mem; /* physical memory */
+    void __iomem *base_addr; /* kernel space memory */
+    uint32_t fpga_addr;
 
-	unsigned int rx_fifo_depth; /* max words in the receive fifo */
-	unsigned int tx_fifo_depth; /* max words in the transmit fifo */
-	unsigned int rx_fifo_pf_thresh; /* programmable full threshold for rx */
-	unsigned int tx_fifo_pf_thresh; /* programmable full threshold for tx */
-	unsigned int rx_fifo_pe_thresh; /* programmable empty threshold for rx */
-	unsigned int tx_fifo_pe_thresh; /* programmable empty threshold for tx */
-	unsigned int tx_max_pkt_size; /* used to trigger poll events */
-	unsigned int rx_min_pkt_size; /* used to trigger poll events */
-	int has_rx_fifo; /* whether the IP has the rx fifo enabled */
-	int has_tx_fifo; /* whether the IP has the tx fifo enabled */
-	int has_tkeep; /* whether the IP has TKEEP enabled or not */
+    unsigned int rx_fifo_depth; /* max words in the receive fifo */
+    unsigned int tx_fifo_depth; /* max words in the transmit fifo */
+    unsigned int rx_fifo_pf_thresh; /* programmable full threshold for rx */
+    unsigned int tx_fifo_pf_thresh; /* programmable full threshold for tx */
+    unsigned int rx_fifo_pe_thresh; /* programmable empty threshold for rx */
+    unsigned int tx_fifo_pe_thresh; /* programmable empty threshold for tx */
+    unsigned int tx_max_pkt_size; /* used to trigger poll events */
+    unsigned int rx_min_pkt_size; /* used to trigger poll events */
+    int has_rx_fifo; /* whether the IP has the rx fifo enabled */
+    int has_tx_fifo; /* whether the IP has the tx fifo enabled */
+    int has_tkeep; /* whether the IP has TKEEP enabled or not */
 
-	wait_queue_head_t read_queue; /* wait queue for asynchronos read */
-	spinlock_t read_queue_lock; /* lock for reading waitqueue */
-	wait_queue_head_t write_queue; /* wait queue for asynchronos write */
-	spinlock_t write_queue_lock; /* lock for writing waitqueue */
-	unsigned int write_flags; /* write file flags */
-	unsigned int read_flags; /* read file flags */
+    wait_queue_head_t read_queue; /* wait queue for asynchronos read */
+    spinlock_t read_queue_lock; /* lock for reading waitqueue */
+    wait_queue_head_t write_queue; /* wait queue for asynchronos write */
+    spinlock_t write_queue_lock; /* lock for writing waitqueue */
+    unsigned int write_flags; /* write file flags */
+    unsigned int read_flags; /* read file flags */
 
-	struct device *dt_device; /* device created from the device tree */
-	struct device *device; /* device associated with char_device */
-	dev_t devt; /* our char device number */
-	struct cdev char_device; /* our char device */
+    struct device *dt_device; /* device created from the device tree */
+    struct device *device; /* device associated with char_device */
+    dev_t devt; /* our char device number */
+    struct cdev char_device; /* our char device */
 };
 
 /* ----------------------------
@@ -119,249 +119,249 @@ static void reset_ip_core(struct axis_fifo *fifo);
  */
 
 static ssize_t sysfs_write(struct device *dev, const char *buf,
-			   size_t count, unsigned int addr_offset)
+               size_t count, unsigned int addr_offset)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned long tmp;
-	int rc;
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned long tmp;
+    int rc;
 
-	rc = kstrtoul(buf, 0, &tmp);
-	if (rc < 0)
-		return rc;
+    rc = kstrtoul(buf, 0, &tmp);
+    if (rc < 0)
+        return rc;
 
-	iowrite32(tmp, fifo->base_addr + addr_offset);
+    iowrite32(tmp, fifo->base_addr + addr_offset);
 
-	return count;
+    return count;
 }
 
 static ssize_t sysfs_read(struct device *dev, char *buf,
-			  unsigned int addr_offset)
+              unsigned int addr_offset)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned int read_val;
-	unsigned int len;
-	char tmp[32];
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned int read_val;
+    unsigned int len;
+    char tmp[32];
 
-	read_val = ioread32(fifo->base_addr + addr_offset);
-	len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
-	memcpy(buf, tmp, len);
+    read_val = ioread32(fifo->base_addr + addr_offset);
+    len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
+    memcpy(buf, tmp, len);
 
-	return len;
+    return len;
 }
 
 static ssize_t isr_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_ISR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_ISR_OFFSET);
 }
 
 static ssize_t isr_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_ISR_OFFSET);
+    return sysfs_read(dev, buf, XLLF_ISR_OFFSET);
 }
 
 static DEVICE_ATTR_RW(isr);
 
 static ssize_t ier_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_IER_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_IER_OFFSET);
 }
 
 static ssize_t ier_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_IER_OFFSET);
+    return sysfs_read(dev, buf, XLLF_IER_OFFSET);
 }
 
 static DEVICE_ATTR_RW(ier);
 
 static ssize_t tdfr_store(struct device *dev, struct device_attribute *attr,
-			  const char *buf, size_t count)
+              const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_TDFR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_TDFR_OFFSET);
 }
 
 static DEVICE_ATTR_WO(tdfr);
 
 static ssize_t tdfv_show(struct device *dev,
-			 struct device_attribute *attr, char *buf)
+             struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_TDFV_OFFSET);
+    return sysfs_read(dev, buf, XLLF_TDFV_OFFSET);
 }
 
 static DEVICE_ATTR_RO(tdfv);
 
 static ssize_t tdfd_store(struct device *dev, struct device_attribute *attr,
-			  const char *buf, size_t count)
+              const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_TDFD_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_TDFD_OFFSET);
 }
 
 static DEVICE_ATTR_WO(tdfd);
 
 static ssize_t tlr_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_TLR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_TLR_OFFSET);
 }
 
 static DEVICE_ATTR_WO(tlr);
 
 static ssize_t rdfr_store(struct device *dev, struct device_attribute *attr,
-			  const char *buf, size_t count)
+              const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_RDFR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_RDFR_OFFSET);
 }
 
 static DEVICE_ATTR_WO(rdfr);
 
 static ssize_t rdfo_show(struct device *dev,
-			 struct device_attribute *attr, char *buf)
+             struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_RDFO_OFFSET);
+    return sysfs_read(dev, buf, XLLF_RDFO_OFFSET);
 }
 
 static DEVICE_ATTR_RO(rdfo);
 
 static ssize_t rdfd_show(struct device *dev,
-			 struct device_attribute *attr, char *buf)
+             struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_RDFD_OFFSET);
+    return sysfs_read(dev, buf, XLLF_RDFD_OFFSET);
 }
 
 static DEVICE_ATTR_RO(rdfd);
 
 static ssize_t rlr_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_RLR_OFFSET);
+    return sysfs_read(dev, buf, XLLF_RLR_OFFSET);
 }
 
 static DEVICE_ATTR_RO(rlr);
 
 static ssize_t srr_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_SRR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_SRR_OFFSET);
 }
 
 static DEVICE_ATTR_WO(srr);
 
 static ssize_t tdr_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	return sysfs_write(dev, buf, count, XLLF_TDR_OFFSET);
+    return sysfs_write(dev, buf, count, XLLF_TDR_OFFSET);
 }
 
 static DEVICE_ATTR_WO(tdr);
 
 static ssize_t rdr_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	return sysfs_read(dev, buf, XLLF_RDR_OFFSET);
+    return sysfs_read(dev, buf, XLLF_RDR_OFFSET);
 }
 
 static DEVICE_ATTR_RO(rdr);
 
 static ssize_t core_reset_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	reset_ip_core(fifo);
-	return 1;
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    reset_ip_core(fifo);
+    return 1;
 }
 
 static DEVICE_ATTR_WO(core_reset);
 
 static ssize_t rx_min_pkt_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned long tmp;
-	int rc;
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned long tmp;
+    int rc;
 
-	rc = kstrtoul(buf, 0, &tmp);
-	if (rc < 0)
-		return rc;
+    rc = kstrtoul(buf, 0, &tmp);
+    if (rc < 0)
+        return rc;
 
-	fifo->rx_min_pkt_size = tmp;
+    fifo->rx_min_pkt_size = tmp;
 
-	return strlen(buf);
+    return strlen(buf);
 }
 
 static ssize_t rx_min_pkt_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned int read_val;
-	unsigned int len;
-	char tmp[32];
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned int read_val;
+    unsigned int len;
+    char tmp[32];
 
-	read_val = fifo->rx_min_pkt_size;
-	len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
-	memcpy(buf, tmp, len);
-	return len;
+    read_val = fifo->rx_min_pkt_size;
+    len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
+    memcpy(buf, tmp, len);
+    return len;
 }
 
 static DEVICE_ATTR_RW(rx_min_pkt);
 
 static ssize_t tx_max_pkt_store(struct device *dev, struct device_attribute *attr,
-			 const char *buf, size_t count)
+             const char *buf, size_t count)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned long tmp;
-	int rc;
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned long tmp;
+    int rc;
 
-	rc = kstrtoul(buf, 0, &tmp);
-	if (rc < 0)
-		return rc;
+    rc = kstrtoul(buf, 0, &tmp);
+    if (rc < 0)
+        return rc;
 
-	fifo->tx_max_pkt_size = tmp;
+    fifo->tx_max_pkt_size = tmp;
 
-	return strlen(buf);
+    return strlen(buf);
 }
 
 static ssize_t tx_max_pkt_show(struct device *dev,
-			struct device_attribute *attr, char *buf)
+            struct device_attribute *attr, char *buf)
 {
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
-	unsigned int read_val;
-	unsigned int len;
-	char tmp[32];
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
+    unsigned int read_val;
+    unsigned int len;
+    char tmp[32];
 
-	read_val = fifo->tx_max_pkt_size;
-	len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
-	memcpy(buf, tmp, len);
-	return len;
+    read_val = fifo->tx_max_pkt_size;
+    len =  snprintf(tmp, sizeof(tmp), "0x%x\n", read_val);
+    memcpy(buf, tmp, len);
+    return len;
 }
 
 static DEVICE_ATTR_RW(tx_max_pkt);
 
 static struct attribute *axis_fifo_attrs[] = {
-	&dev_attr_isr.attr,
-	&dev_attr_ier.attr,
-	&dev_attr_tdfr.attr,
-	&dev_attr_tdfv.attr,
-	&dev_attr_tdfd.attr,
-	&dev_attr_tlr.attr,
-	&dev_attr_rdfr.attr,
-	&dev_attr_rdfo.attr,
-	&dev_attr_rdfd.attr,
-	&dev_attr_rlr.attr,
-	&dev_attr_srr.attr,
-	&dev_attr_tdr.attr,
-	&dev_attr_rdr.attr,
-	&dev_attr_core_reset.attr,
-	&dev_attr_tx_max_pkt.attr,
-	&dev_attr_rx_min_pkt.attr,
-	NULL,
+    &dev_attr_isr.attr,
+    &dev_attr_ier.attr,
+    &dev_attr_tdfr.attr,
+    &dev_attr_tdfv.attr,
+    &dev_attr_tdfd.attr,
+    &dev_attr_tlr.attr,
+    &dev_attr_rdfr.attr,
+    &dev_attr_rdfo.attr,
+    &dev_attr_rdfd.attr,
+    &dev_attr_rlr.attr,
+    &dev_attr_srr.attr,
+    &dev_attr_tdr.attr,
+    &dev_attr_rdr.attr,
+    &dev_attr_core_reset.attr,
+    &dev_attr_tx_max_pkt.attr,
+    &dev_attr_rx_min_pkt.attr,
+    NULL,
 };
 
 static const struct attribute_group axis_fifo_attrs_group = {
-	.name = "ip_registers",
-	.attrs = axis_fifo_attrs,
+    .name = "ip_registers",
+    .attrs = axis_fifo_attrs,
 };
 
 /* ----------------------------
@@ -371,277 +371,277 @@ static const struct attribute_group axis_fifo_attrs_group = {
 
 static void reset_ip_core(struct axis_fifo *fifo)
 {
-	iowrite32(XLLF_SRR_RESET_MASK, fifo->base_addr + XLLF_SRR_OFFSET);
-	iowrite32(XLLF_TDFR_RESET_MASK, fifo->base_addr + XLLF_TDFR_OFFSET);
-	iowrite32(XLLF_RDFR_RESET_MASK, fifo->base_addr + XLLF_RDFR_OFFSET);
-	iowrite32(XLLF_INT_TC_MASK | XLLF_INT_RC_MASK | XLLF_INT_RPURE_MASK |
-		  XLLF_INT_RPORE_MASK | XLLF_INT_RPUE_MASK |
-		  XLLF_INT_TPOE_MASK | XLLF_INT_TSE_MASK,
-		  fifo->base_addr + XLLF_IER_OFFSET);
-	iowrite32(XLLF_INT_ALL_MASK, fifo->base_addr + XLLF_ISR_OFFSET);
+    iowrite32(XLLF_SRR_RESET_MASK, fifo->base_addr + XLLF_SRR_OFFSET);
+    iowrite32(XLLF_TDFR_RESET_MASK, fifo->base_addr + XLLF_TDFR_OFFSET);
+    iowrite32(XLLF_RDFR_RESET_MASK, fifo->base_addr + XLLF_RDFR_OFFSET);
+    iowrite32(XLLF_INT_TC_MASK | XLLF_INT_RC_MASK | XLLF_INT_RPURE_MASK |
+          XLLF_INT_RPORE_MASK | XLLF_INT_RPUE_MASK |
+          XLLF_INT_TPOE_MASK | XLLF_INT_TSE_MASK,
+          fifo->base_addr + XLLF_IER_OFFSET);
+    iowrite32(XLLF_INT_ALL_MASK, fifo->base_addr + XLLF_ISR_OFFSET);
 }
 
 static unsigned int axis_poll(struct file *file, poll_table *wait)
 {
-	unsigned int mask;
-	struct axis_fifo *fifo = (struct axis_fifo *)file->private_data;
-	unsigned int rdfo;
-	unsigned int tdfv;
-	mask = 0;
+    unsigned int mask;
+    struct axis_fifo *fifo = (struct axis_fifo *)file->private_data;
+    unsigned int rdfo;
+    unsigned int tdfv;
+    mask = 0;
 
-	if (fifo->has_rx_fifo)
-		poll_wait(file, &axis_read_wait, wait);
-	if (fifo->has_tx_fifo)
-		poll_wait(file, &axis_write_wait, wait);
+    if (fifo->has_rx_fifo)
+        poll_wait(file, &axis_read_wait, wait);
+    if (fifo->has_tx_fifo)
+        poll_wait(file, &axis_write_wait, wait);
 
-	/* user should set the rx-min-pkt-size
-	* in the device tree to indicate when POLLIN will return 
-	* NOTE : rx-min-pkt-size is in WORDS not BYTES 
-	*/
-	if (fifo->has_rx_fifo) {
-		rdfo = ioread32(fifo->base_addr + XLLF_RDFO_OFFSET);
-		if (rdfo > fifo->rx_min_pkt_size){
-			mask |= POLLIN | POLLRDNORM;
-		}		
-	}
+    /* user should set the rx-min-pkt-size
+    * in the device tree to indicate when POLLIN will return
+    * NOTE : rx-min-pkt-size is in WORDS not BYTES
+    */
+    if (fifo->has_rx_fifo) {
+        rdfo = ioread32(fifo->base_addr + XLLF_RDFO_OFFSET);
+        if (rdfo > fifo->rx_min_pkt_size){
+            mask |= POLLIN | POLLRDNORM;
+        }
+    }
 
-	/* user should set the tx-max-pkt-size
-	* in the device tree to indicate when POLLOUT will return 
-	* NOTE : tx-max-pkt-size is in WORDS not BYTES 
-	*/
-	if (fifo->has_tx_fifo) {
-		tdfv = ioread32(fifo->base_addr + XLLF_TDFV_OFFSET);
-		if (tdfv > fifo->tx_max_pkt_size){ 
-			mask |= POLLOUT;
-       		}
-	}
+    /* user should set the tx-max-pkt-size
+    * in the device tree to indicate when POLLOUT will return
+    * NOTE : tx-max-pkt-size is in WORDS not BYTES
+    */
+    if (fifo->has_tx_fifo) {
+        tdfv = ioread32(fifo->base_addr + XLLF_TDFV_OFFSET);
+        if (tdfv > fifo->tx_max_pkt_size){
+            mask |= POLLOUT;
+            }
+    }
 
-	return mask;
+    return mask;
 }
 
 /* reads a single packet from the fifo as dictated by the tlast signal */
 static ssize_t axis_fifo_read(struct file *f, char __user *buf,
-			      size_t len, loff_t *off)
+                  size_t len, loff_t *off)
 {
-	struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
-	size_t bytes_available;
-	unsigned int words_available;
+    struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
+    size_t bytes_available;
+    unsigned int words_available;
         unsigned int leftover;
-	unsigned int copied;
-	unsigned int copy;
-	unsigned int i;
-	int ret;
-	u32 tmp_buf[READ_BUF_SIZE];
+    unsigned int copied;
+    unsigned int copy;
+    unsigned int i;
+    int ret;
+    u32 tmp_buf[READ_BUF_SIZE];
 
-	if (fifo->read_flags & O_NONBLOCK) {
-		/* opened in non-blocking mode
-		 * return if there are no packets available
-		 */
-		if (!ioread32(fifo->base_addr + XLLF_RDFO_OFFSET))
-			return -EAGAIN;
-	} else {
-		/* opened in blocking mode
-		 * wait for a packet available interrupt (or timeout)
-		 * if nothing is currently available
-		 */
-		spin_lock_irq(&fifo->read_queue_lock);
-		ret = wait_event_interruptible_lock_irq_timeout(
-			fifo->read_queue,
-			ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
-			fifo->read_queue_lock,
-			(read_timeout >= 0) ? msecs_to_jiffies(read_timeout) :
-				MAX_SCHEDULE_TIMEOUT);
-		spin_unlock_irq(&fifo->read_queue_lock);
+    if (fifo->read_flags & O_NONBLOCK) {
+        /* opened in non-blocking mode
+         * return if there are no packets available
+         */
+        if (!ioread32(fifo->base_addr + XLLF_RDFO_OFFSET))
+            return -EAGAIN;
+    } else {
+        /* opened in blocking mode
+         * wait for a packet available interrupt (or timeout)
+         * if nothing is currently available
+         */
+        spin_lock_irq(&fifo->read_queue_lock);
+        ret = wait_event_interruptible_lock_irq_timeout(
+            fifo->read_queue,
+            ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
+            fifo->read_queue_lock,
+            (read_timeout >= 0) ? msecs_to_jiffies(read_timeout) :
+                MAX_SCHEDULE_TIMEOUT);
+        spin_unlock_irq(&fifo->read_queue_lock);
                 wake_up_interruptible(&axis_read_wait);
 
-		if (ret == 0) {
-			/* timeout occurred */
-			dev_dbg(fifo->dt_device, "read timeout");
-			return -EAGAIN;
-		} else if (ret == -ERESTARTSYS) {
-			/* signal received */
-			return -ERESTARTSYS;
-		} else if (ret < 0) {
-			dev_err(fifo->dt_device, "wait_event_interruptible_timeout() error in read (ret=%i)\n",
-				ret);
-			return ret;
-		}
-	}
+        if (ret == 0) {
+            /* timeout occurred */
+            dev_dbg(fifo->dt_device, "read timeout");
+            return -EAGAIN;
+        } else if (ret == -ERESTARTSYS) {
+            /* signal received */
+            return -ERESTARTSYS;
+        } else if (ret < 0) {
+            dev_err(fifo->dt_device, "wait_event_interruptible_timeout() error in read (ret=%i)\n",
+                ret);
+            return ret;
+        }
+    }
 
-	bytes_available = ioread32(fifo->base_addr + XLLF_RLR_OFFSET);
-	if (!bytes_available) {
-		dev_err(fifo->dt_device, "received a packet of length 0 - fifo core will be reset\n");
-		reset_ip_core(fifo);
-		return -EIO;
-	}
+    bytes_available = ioread32(fifo->base_addr + XLLF_RLR_OFFSET);
+    if (!bytes_available) {
+        dev_err(fifo->dt_device, "received a packet of length 0 - fifo core will be reset\n");
+        reset_ip_core(fifo);
+        return -EIO;
+    }
 
-	if (bytes_available > len) {
-		dev_err(fifo->dt_device, "user read buffer too small (available bytes=%zu user buffer bytes=%zu) - fifo core will be reset\n",
-			bytes_available, len);
-		reset_ip_core(fifo);
-		return -EINVAL;
-	}
+    if (bytes_available > len) {
+        dev_err(fifo->dt_device, "user read buffer too small (available bytes=%zu user buffer bytes=%zu) - fifo core will be reset\n",
+            bytes_available, len);
+        reset_ip_core(fifo);
+        return -EINVAL;
+    }
 
-	if (!fifo->has_tkeep && bytes_available % sizeof(u32)) {
-		/* this probably can't happen unless IP
-		 * registers were previously mishandled
-		 */
-		dev_err(fifo->dt_device, "received a packet that isn't word-aligned - fifo core will be reset\n");
-		reset_ip_core(fifo);
-		return -EIO;
-	}
+    if (!fifo->has_tkeep && bytes_available % sizeof(u32)) {
+        /* this probably can't happen unless IP
+         * registers were previously mishandled
+         */
+        dev_err(fifo->dt_device, "received a packet that isn't word-aligned - fifo core will be reset\n");
+        reset_ip_core(fifo);
+        return -EIO;
+    }
 
-	words_available = bytes_available / sizeof(u32);
+    words_available = bytes_available / sizeof(u32);
 
 #ifdef AXIS_FIFO_DEBUG_PRINT
-	dev_err(fifo->dt_device,"read: rdfo : %d ... tdfv : %d ... rlr : %d\n",
-		ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
-		ioread32(fifo->base_addr + XLLF_TDFV_OFFSET),
-		bytes_available);
+    dev_err(fifo->dt_device,"read: rdfo : %d ... tdfv : %d ... rlr : %d\n",
+        ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
+        ioread32(fifo->base_addr + XLLF_TDFV_OFFSET),
+        bytes_available);
 #endif
 
-	/* read data into an intermediate buffer, copying the contents
-	 * to userspace when the buffer is full
-	 */
-	copied = 0;
-	while (words_available > 0) {
-		copy = min(words_available, READ_BUF_SIZE);
+    /* read data into an intermediate buffer, copying the contents
+     * to userspace when the buffer is full
+     */
+    copied = 0;
+    while (words_available > 0) {
+        copy = min(words_available, READ_BUF_SIZE);
 
-		for (i = 0; i < copy; i++) {
-			tmp_buf[i] = ioread32(fifo->base_addr +
-					      XLLF_RDFD_OFFSET);
-		}
+        for (i = 0; i < copy; i++) {
+            tmp_buf[i] = ioread32(fifo->base_addr +
+                          XLLF_RDFD_OFFSET);
+        }
 
-		if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
-				 copy * sizeof(u32))) {
-			reset_ip_core(fifo);
-			return -EFAULT;
-		}
+        if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
+                 copy * sizeof(u32))) {
+            reset_ip_core(fifo);
+            return -EFAULT;
+        }
 
-		copied += copy;
-		words_available -= copy;
-	}
+        copied += copy;
+        words_available -= copy;
+    }
 
-	if (fifo->has_tkeep) {
-		leftover = bytes_available % sizeof(u32);
-		if (leftover) {
-			tmp_buf[0] = ioread32(fifo->base_addr +
-				                  XLLF_RDFD_OFFSET);
+    if (fifo->has_tkeep) {
+        leftover = bytes_available % sizeof(u32);
+        if (leftover) {
+            tmp_buf[0] = ioread32(fifo->base_addr +
+                                  XLLF_RDFD_OFFSET);
 
-			if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
-				         leftover)) {
-				reset_ip_core(fifo);
-				return -EFAULT;
-			}
-		}
-	}	
+            if (copy_to_user(buf + copied * sizeof(u32), tmp_buf,
+                         leftover)) {
+                reset_ip_core(fifo);
+                return -EFAULT;
+            }
+        }
+    }
 
-	return bytes_available;
+    return bytes_available;
 }
 
 static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
-			       size_t len, loff_t *off)
+                   size_t len, loff_t *off)
 {
-	struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
-	unsigned int words_to_write;
-	unsigned int copied;
+    struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
+    unsigned int words_to_write;
+    unsigned int copied;
         unsigned int copiedBytes;
-	unsigned int copy;
-	unsigned int i;
-	int ret;
-	u32 tmp_buf[WRITE_BUF_SIZE];
+    unsigned int copy;
+    unsigned int i;
+    int ret;
+    u32 tmp_buf[WRITE_BUF_SIZE];
         int leftover;
 
-	if (!fifo->has_tkeep && len % sizeof(u32)) {
-		dev_err(fifo->dt_device,
-		    "tried to send a packet that isn't word-aligned\n");
-		return -EINVAL;
-	}
+    if (!fifo->has_tkeep && len % sizeof(u32)) {
+        dev_err(fifo->dt_device,
+            "tried to send a packet that isn't word-aligned\n");
+        return -EINVAL;
+    }
 
-	words_to_write = len / sizeof(u32);
+    words_to_write = len / sizeof(u32);
         leftover = len % sizeof(u32);
 
-	if (!words_to_write) {
-		dev_err(fifo->dt_device,
-			"tried to send a packet of length 0\n");
-		return -EINVAL;
-	}
+    if (!words_to_write) {
+        dev_err(fifo->dt_device,
+            "tried to send a packet of length 0\n");
+        return -EINVAL;
+    }
 
-	if (words_to_write > fifo->tx_fifo_depth) {
-		dev_err(fifo->dt_device, "tried to write more words [%u] than slots in the fifo buffer [%u]\n",
-			words_to_write, fifo->tx_fifo_depth);
-		return -EINVAL;
-	}
+    if (words_to_write > fifo->tx_fifo_depth) {
+        dev_err(fifo->dt_device, "tried to write more words [%u] than slots in the fifo buffer [%u]\n",
+            words_to_write, fifo->tx_fifo_depth);
+        return -EINVAL;
+    }
 
-	if (fifo->write_flags & O_NONBLOCK) {
-		/* opened in non-blocking mode
-		 * return if there is not enough room available in the fifo
-		 */
-		if (words_to_write > ioread32(fifo->base_addr +
-					      XLLF_TDFV_OFFSET)) {
-			return -EAGAIN;
-		}
-	} else {
-		/* opened in blocking mode */
+    if (fifo->write_flags & O_NONBLOCK) {
+        /* opened in non-blocking mode
+         * return if there is not enough room available in the fifo
+         */
+        if (words_to_write > ioread32(fifo->base_addr +
+                          XLLF_TDFV_OFFSET)) {
+            return -EAGAIN;
+        }
+    } else {
+        /* opened in blocking mode */
 
-		/* wait for an interrupt (or timeout) if there isn't
-		 * currently enough room in the fifo
-		 */
-		spin_lock_irq(&fifo->write_queue_lock);
-		ret = wait_event_interruptible_lock_irq_timeout(
-			fifo->write_queue,
-			ioread32(fifo->base_addr + XLLF_TDFV_OFFSET)
-				>= words_to_write,
-			fifo->write_queue_lock,
-			(write_timeout >= 0) ? msecs_to_jiffies(write_timeout) :
-				MAX_SCHEDULE_TIMEOUT);
-		spin_unlock_irq(&fifo->write_queue_lock);
+        /* wait for an interrupt (or timeout) if there isn't
+         * currently enough room in the fifo
+         */
+        spin_lock_irq(&fifo->write_queue_lock);
+        ret = wait_event_interruptible_lock_irq_timeout(
+            fifo->write_queue,
+            ioread32(fifo->base_addr + XLLF_TDFV_OFFSET)
+                >= words_to_write,
+            fifo->write_queue_lock,
+            (write_timeout >= 0) ? msecs_to_jiffies(write_timeout) :
+                MAX_SCHEDULE_TIMEOUT);
+        spin_unlock_irq(&fifo->write_queue_lock);
                 wake_up_interruptible(&axis_write_wait);
 
-		if (ret == 0) {
-			/* timeout occurred */
-			dev_dbg(fifo->dt_device, "write timeout\n");
-			return -EAGAIN;
-		} else if (ret == -ERESTARTSYS) {
-			/* signal received */
-			return -ERESTARTSYS;
-		} else if (ret < 0) {
-			/* unknown error */
-			dev_err(fifo->dt_device,
-				"wait_event_interruptible_timeout() error in write (ret=%i)\n",
-				ret);
-			return ret;
-		}
-	}
+        if (ret == 0) {
+            /* timeout occurred */
+            dev_dbg(fifo->dt_device, "write timeout\n");
+            return -EAGAIN;
+        } else if (ret == -ERESTARTSYS) {
+            /* signal received */
+            return -ERESTARTSYS;
+        } else if (ret < 0) {
+            /* unknown error */
+            dev_err(fifo->dt_device,
+                "wait_event_interruptible_timeout() error in write (ret=%i)\n",
+                ret);
+            return ret;
+        }
+    }
 
 #ifdef AXIS_FIFO_DEBUG_PRINT
-	dev_err(fifo->dt_device,"write: rdfo : %d ... tdfv : %d\n",
-		ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
-		ioread32(fifo->base_addr + XLLF_TDFV_OFFSET));
+    dev_err(fifo->dt_device,"write: rdfo : %d ... tdfv : %d\n",
+        ioread32(fifo->base_addr + XLLF_RDFO_OFFSET),
+        ioread32(fifo->base_addr + XLLF_TDFV_OFFSET));
 #endif
 
-	/* write data from an intermediate buffer into the fifo IP, refilling
-	 * the buffer with userspace data as needed
-	 */
-	copied = 0;
-	while (words_to_write > 0) {
-		copy = min(words_to_write, WRITE_BUF_SIZE);
+    /* write data from an intermediate buffer into the fifo IP, refilling
+     * the buffer with userspace data as needed
+     */
+    copied = 0;
+    while (words_to_write > 0) {
+        copy = min(words_to_write, WRITE_BUF_SIZE);
 
-		if (copy_from_user(tmp_buf, buf + copied * sizeof(u32),
-				   copy * sizeof(u32))) {
-			reset_ip_core(fifo);
-			return -EFAULT;
-		}
+        if (copy_from_user(tmp_buf, buf + copied * sizeof(u32),
+                   copy * sizeof(u32))) {
+            reset_ip_core(fifo);
+            return -EFAULT;
+        }
 
-		for (i = 0; i < copy; i++)
-			iowrite32(tmp_buf[i], fifo->base_addr +
-				  XLLF_TDFD_OFFSET);
+        for (i = 0; i < copy; i++)
+            iowrite32(tmp_buf[i], fifo->base_addr +
+                  XLLF_TDFD_OFFSET);
 
-		copied += copy;
-		words_to_write -= copy;
-	}
+        copied += copy;
+        words_to_write -= copy;
+    }
 
-	if (fifo->has_tkeep && leftover) {	
+    if (fifo->has_tkeep && leftover) {
                 if (copy_from_user(tmp_buf, buf + copied * sizeof(u32),
                                    leftover)) {
                         reset_ip_core(fifo);
@@ -652,7 +652,7 @@ static ssize_t axis_fifo_write(struct file *f, const char __user *buf,
         }
 
         /* write packet size to fifo */
-	copiedBytes = (fifo->has_tkeep && !!leftover) ? (copied*sizeof(u32)+leftover) : (copied*sizeof(u32));
+    copiedBytes = (fifo->has_tkeep && !!leftover) ? (copied*sizeof(u32)+leftover) : (copied*sizeof(u32));
         iowrite32(copiedBytes, fifo->base_addr + XLLF_TLR_OFFSET);
 
         return (ssize_t)copiedBytes;
@@ -666,7 +666,7 @@ static long axis_fifo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
     void *__user arg_ptr;
     uint32_t temp_reg;
     struct axis_fifo_kern_regInfo regInfo;
-	struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
+    struct axis_fifo *fifo = (struct axis_fifo *)f->private_data;
 
     if (mutex_lock_interruptible(&ioctl_lock))
         return -EINTR;
@@ -705,6 +705,15 @@ static long axis_fifo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
                 return -EFAULT;
             }
             iowrite32(regInfo.regVal, fifo->base_addr + regInfo.regNo);
+            rc = 0;
+            break;
+
+        case AXIS_FIFO_GET_TX_VACANCY:
+            temp_reg = ioread32(fifo->base_addr + XLLF_TDFV_OFFSET);
+            if (copy_to_user(arg_ptr, &temp_reg, sizeof(temp_reg))) {
+                dev_err(fifo->dt_device, "unable to copy status reg to userspace\n");
+                return -EFAULT;
+            }
             rc = 0;
             break;
 
@@ -760,595 +769,595 @@ static long axis_fifo_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
         default:
             return -ENOTTY;
     }
-    
+
     mutex_unlock(&ioctl_lock);
     return rc;
 }
 static irqreturn_t axis_fifo_irq(int irq, void *dw)
 {
-	struct axis_fifo *fifo = (struct axis_fifo *)dw;
-	unsigned int pending_interrupts;
+    struct axis_fifo *fifo = (struct axis_fifo *)dw;
+    unsigned int pending_interrupts;
 
-	do {
-		pending_interrupts = ioread32(fifo->base_addr +
-					      XLLF_IER_OFFSET) &
-					      ioread32(fifo->base_addr
-					      + XLLF_ISR_OFFSET);
-		if (pending_interrupts & XLLF_INT_RC_MASK) {
-			/* packet received */
+    do {
+        pending_interrupts = ioread32(fifo->base_addr +
+                          XLLF_IER_OFFSET) &
+                          ioread32(fifo->base_addr
+                          + XLLF_ISR_OFFSET);
+        if (pending_interrupts & XLLF_INT_RC_MASK) {
+            /* packet received */
 
-			/* wake the reader process if it is waiting */
-			wake_up(&fifo->read_queue);
-			wake_up_interruptible(&axis_read_wait);
+            /* wake the reader process if it is waiting */
+            wake_up(&fifo->read_queue);
+            wake_up_interruptible(&axis_read_wait);
 
-			/* clear interrupt */
-			iowrite32(XLLF_INT_RC_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TC_MASK) {
-			/* packet sent */
+            /* clear interrupt */
+            iowrite32(XLLF_INT_RC_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TC_MASK) {
+            /* packet sent */
 
-			/* wake the writer process if it is waiting */
-			wake_up(&fifo->write_queue);
-			wake_up_interruptible(&axis_write_wait);
+            /* wake the writer process if it is waiting */
+            wake_up(&fifo->write_queue);
+            wake_up_interruptible(&axis_write_wait);
 
-			iowrite32(XLLF_INT_TC_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TFPF_MASK) {
-			/* transmit fifo programmable full */
+            iowrite32(XLLF_INT_TC_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TFPF_MASK) {
+            /* transmit fifo programmable full */
 
-			iowrite32(XLLF_INT_TFPF_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TFPE_MASK) {
-			/* transmit fifo programmable empty */
+            iowrite32(XLLF_INT_TFPF_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TFPE_MASK) {
+            /* transmit fifo programmable empty */
 
-			wake_up_interruptible(&axis_write_wait);
-			iowrite32(XLLF_INT_TFPE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RFPF_MASK) {
-			/* receive fifo programmable full */
+            wake_up_interruptible(&axis_write_wait);
+            iowrite32(XLLF_INT_TFPE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RFPF_MASK) {
+            /* receive fifo programmable full */
 
-			wake_up_interruptible(&axis_read_wait);
-			iowrite32(XLLF_INT_RFPF_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RFPE_MASK) {
-			/* receive fifo programmable empty */
+            wake_up_interruptible(&axis_read_wait);
+            iowrite32(XLLF_INT_RFPF_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RFPE_MASK) {
+            /* receive fifo programmable empty */
 
-			iowrite32(XLLF_INT_RFPE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TRC_MASK) {
-			/* transmit reset complete interrupt */
+            iowrite32(XLLF_INT_RFPE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TRC_MASK) {
+            /* transmit reset complete interrupt */
 
-			iowrite32(XLLF_INT_TRC_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RRC_MASK) {
-			/* receive reset complete interrupt */
+            iowrite32(XLLF_INT_TRC_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RRC_MASK) {
+            /* receive reset complete interrupt */
 
-			iowrite32(XLLF_INT_RRC_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RPURE_MASK) {
-			/* receive fifo under-read error interrupt */
-			dev_err(fifo->dt_device,
-				"receive under-read interrupt\n");
+            iowrite32(XLLF_INT_RRC_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RPURE_MASK) {
+            /* receive fifo under-read error interrupt */
+            dev_err(fifo->dt_device,
+                "receive under-read interrupt\n");
 
-			iowrite32(XLLF_INT_RPURE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RPORE_MASK) {
-			/* receive over-read error interrupt */
-			dev_err(fifo->dt_device,
-				"receive over-read interrupt\n");
+            iowrite32(XLLF_INT_RPURE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RPORE_MASK) {
+            /* receive over-read error interrupt */
+            dev_err(fifo->dt_device,
+                "receive over-read interrupt\n");
 
-			iowrite32(XLLF_INT_RPORE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_RPUE_MASK) {
-			/* receive underrun error interrupt */
-			dev_err(fifo->dt_device,
-				"receive underrun error interrupt\n");
+            iowrite32(XLLF_INT_RPORE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_RPUE_MASK) {
+            /* receive underrun error interrupt */
+            dev_err(fifo->dt_device,
+                "receive underrun error interrupt\n");
 
-			iowrite32(XLLF_INT_RPUE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TPOE_MASK) {
-			/* transmit overrun error interrupt */
-			dev_err(fifo->dt_device,
-				"transmit overrun error interrupt\n");
+            iowrite32(XLLF_INT_RPUE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TPOE_MASK) {
+            /* transmit overrun error interrupt */
+            dev_err(fifo->dt_device,
+                "transmit overrun error interrupt\n");
 
-			iowrite32(XLLF_INT_TPOE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts & XLLF_INT_TSE_MASK) {
-			/* transmit length mismatch error interrupt */
-			dev_err(fifo->dt_device,
-				"transmit length mismatch error interrupt\n");
+            iowrite32(XLLF_INT_TPOE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts & XLLF_INT_TSE_MASK) {
+            /* transmit length mismatch error interrupt */
+            dev_err(fifo->dt_device,
+                "transmit length mismatch error interrupt\n");
 
-			iowrite32(XLLF_INT_TSE_MASK & XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		} else if (pending_interrupts) {
-			/* unknown interrupt type */
-			dev_err(fifo->dt_device,
-				"unknown interrupt(s) 0x%x\n",
-				pending_interrupts);
+            iowrite32(XLLF_INT_TSE_MASK & XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        } else if (pending_interrupts) {
+            /* unknown interrupt type */
+            dev_err(fifo->dt_device,
+                "unknown interrupt(s) 0x%x\n",
+                pending_interrupts);
 
-			iowrite32(XLLF_INT_ALL_MASK,
-				  fifo->base_addr + XLLF_ISR_OFFSET);
-		}
-	} while (pending_interrupts);
+            iowrite32(XLLF_INT_ALL_MASK,
+                  fifo->base_addr + XLLF_ISR_OFFSET);
+        }
+    } while (pending_interrupts);
 
-	return IRQ_HANDLED;
+    return IRQ_HANDLED;
 }
 
 static int axis_fifo_open(struct inode *inod, struct file *f)
 {
-	struct axis_fifo *fifo = (struct axis_fifo *)container_of(inod->i_cdev,
-					struct axis_fifo, char_device);
-	f->private_data = fifo;
+    struct axis_fifo *fifo = (struct axis_fifo *)container_of(inod->i_cdev,
+                    struct axis_fifo, char_device);
+    f->private_data = fifo;
 
-	if (((f->f_flags & O_ACCMODE) == O_WRONLY) ||
-	    ((f->f_flags & O_ACCMODE) == O_RDWR)) {
-		if (fifo->has_tx_fifo) {
-			fifo->write_flags = f->f_flags;
-		} else {
-			dev_err(fifo->dt_device, "tried to open device for write but the transmit fifo is disabled\n");
-			return -EPERM;
-		}
-	}
+    if (((f->f_flags & O_ACCMODE) == O_WRONLY) ||
+        ((f->f_flags & O_ACCMODE) == O_RDWR)) {
+        if (fifo->has_tx_fifo) {
+            fifo->write_flags = f->f_flags;
+        } else {
+            dev_err(fifo->dt_device, "tried to open device for write but the transmit fifo is disabled\n");
+            return -EPERM;
+        }
+    }
 
-	if (((f->f_flags & O_ACCMODE) == O_RDONLY) ||
-	    ((f->f_flags & O_ACCMODE) == O_RDWR)) {
-		if (fifo->has_rx_fifo) {
-			fifo->read_flags = f->f_flags;
-		} else {
-			dev_err(fifo->dt_device, "tried to open device for read but the receive fifo is disabled\n");
-			return -EPERM;
-		}
-	}
+    if (((f->f_flags & O_ACCMODE) == O_RDONLY) ||
+        ((f->f_flags & O_ACCMODE) == O_RDWR)) {
+        if (fifo->has_rx_fifo) {
+            fifo->read_flags = f->f_flags;
+        } else {
+            dev_err(fifo->dt_device, "tried to open device for read but the receive fifo is disabled\n");
+            return -EPERM;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 static int axis_fifo_close(struct inode *inod, struct file *f)
 {
-	f->private_data = NULL;
+    f->private_data = NULL;
 
-	return 0;
+    return 0;
 }
 
 static const struct file_operations fops = {
-	.owner = THIS_MODULE,
-	.open = axis_fifo_open,
-	.release = axis_fifo_close,
-	.unlocked_ioctl = axis_fifo_ioctl,
-	.read = axis_fifo_read,
-	.write = axis_fifo_write,
-	.poll = axis_poll
+    .owner = THIS_MODULE,
+    .open = axis_fifo_open,
+    .release = axis_fifo_close,
+    .unlocked_ioctl = axis_fifo_ioctl,
+    .read = axis_fifo_read,
+    .write = axis_fifo_write,
+    .poll = axis_poll
 };
 
 /* read named property from the device tree */
 static int get_dts_property(struct axis_fifo *fifo,
-			    char *name, unsigned int *var)
+                char *name, unsigned int *var)
 {
-	int rc;
+    int rc;
 
-	rc = of_property_read_u32(fifo->dt_device->of_node, name, var);
-	if (rc) {
-		dev_err(fifo->dt_device, "couldn't read IP dts property '%s'",
-			name);
-		return rc;
-	}
-	dev_dbg(fifo->dt_device, "dts property '%s' = %u\n",
-		name, *var);
+    rc = of_property_read_u32(fifo->dt_device->of_node, name, var);
+    if (rc) {
+        dev_err(fifo->dt_device, "couldn't read IP dts property '%s'",
+            name);
+        return rc;
+    }
+    dev_dbg(fifo->dt_device, "dts property '%s' = %u\n",
+        name, *var);
 
-	return 0;
+    return 0;
 }
 
 static int axis_fifo_probe(struct platform_device *pdev)
 {
-	struct resource *r_irq; /* interrupt resources */
-	struct resource *r_mem; /* IO mem resources */
-	struct device *dev = &pdev->dev; /* OS device (from device tree) */
-	struct axis_fifo *fifo = NULL;
+    struct resource *r_irq; /* interrupt resources */
+    struct resource *r_mem; /* IO mem resources */
+    struct device *dev = &pdev->dev; /* OS device (from device tree) */
+    struct axis_fifo *fifo = NULL;
 
-	char device_name[32];
+    char device_name[32];
 
-	int rc = 0; /* error return value */
+    int rc = 0; /* error return value */
 
-	/* IP properties from device tree */
-	unsigned int rxd_tdata_width;
-	unsigned int txc_tdata_width;
-	unsigned int txd_tdata_width;
-	unsigned int tdest_width;
-	unsigned int tid_width;
-	unsigned int tuser_width;
-	unsigned int data_interface_type;
-	unsigned int has_tdest;
-	unsigned int has_tid;
-	unsigned int has_tkeep;
-	unsigned int has_tstrb;
-	unsigned int has_tuser;
-	unsigned int rx_fifo_depth;
-	unsigned int rx_programmable_empty_threshold;
-	unsigned int rx_programmable_full_threshold;
-	unsigned int axi_id_width;
-	unsigned int axi4_data_width;
-	unsigned int select_xpm;
-	unsigned int tx_fifo_depth;
-	unsigned int tx_programmable_empty_threshold;
-	unsigned int tx_programmable_full_threshold;
-	unsigned int use_rx_cut_through;
-	unsigned int use_rx_data;
-	unsigned int use_tx_control;
-	unsigned int use_tx_cut_through;
-	unsigned int use_tx_data;
-	unsigned int tx_max_pkt_size;
-	unsigned int rx_min_pkt_size;
+    /* IP properties from device tree */
+    unsigned int rxd_tdata_width;
+    unsigned int txc_tdata_width;
+    unsigned int txd_tdata_width;
+    unsigned int tdest_width;
+    unsigned int tid_width;
+    unsigned int tuser_width;
+    unsigned int data_interface_type;
+    unsigned int has_tdest;
+    unsigned int has_tid;
+    unsigned int has_tkeep;
+    unsigned int has_tstrb;
+    unsigned int has_tuser;
+    unsigned int rx_fifo_depth;
+    unsigned int rx_programmable_empty_threshold;
+    unsigned int rx_programmable_full_threshold;
+    unsigned int axi_id_width;
+    unsigned int axi4_data_width;
+    unsigned int select_xpm;
+    unsigned int tx_fifo_depth;
+    unsigned int tx_programmable_empty_threshold;
+    unsigned int tx_programmable_full_threshold;
+    unsigned int use_rx_cut_through;
+    unsigned int use_rx_data;
+    unsigned int use_tx_control;
+    unsigned int use_tx_cut_through;
+    unsigned int use_tx_data;
+    unsigned int tx_max_pkt_size;
+    unsigned int rx_min_pkt_size;
 
-	/* ----------------------------
-	 *     init wrapper device
-	 * ----------------------------
-	 */
+    /* ----------------------------
+     *     init wrapper device
+     * ----------------------------
+     */
 
-	/* allocate device wrapper memory */
-	fifo = devm_kmalloc(dev, sizeof(*fifo), GFP_KERNEL);
-	if (!fifo)
-		return -ENOMEM;
+    /* allocate device wrapper memory */
+    fifo = devm_kmalloc(dev, sizeof(*fifo), GFP_KERNEL);
+    if (!fifo)
+        return -ENOMEM;
 
-	dev_set_drvdata(dev, fifo);
-	fifo->dt_device = dev;
+    dev_set_drvdata(dev, fifo);
+    fifo->dt_device = dev;
 
-	init_waitqueue_head(&fifo->read_queue);
-	init_waitqueue_head(&fifo->write_queue);
+    init_waitqueue_head(&fifo->read_queue);
+    init_waitqueue_head(&fifo->write_queue);
 
-	spin_lock_init(&fifo->read_queue_lock);
-	spin_lock_init(&fifo->write_queue_lock);
+    spin_lock_init(&fifo->read_queue_lock);
+    spin_lock_init(&fifo->write_queue_lock);
 
-	/* ----------------------------
-	 *   init device memory space
-	 * ----------------------------
-	 */
+    /* ----------------------------
+     *   init device memory space
+     * ----------------------------
+     */
 
-	/* get iospace for the device */
-	r_mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (!r_mem) {
-		dev_err(fifo->dt_device, "invalid address\n");
-		rc = -ENODEV;
-		goto err_initial;
-	}
+    /* get iospace for the device */
+    r_mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    if (!r_mem) {
+        dev_err(fifo->dt_device, "invalid address\n");
+        rc = -ENODEV;
+        goto err_initial;
+    }
 
-	fifo->mem = r_mem;
+    fifo->mem = r_mem;
 
-	/* request physical memory */
-	if (!request_mem_region(fifo->mem->start, resource_size(fifo->mem),
-				DRIVER_NAME)) {
-		dev_err(fifo->dt_device,
-			"couldn't lock memory region at 0x%pa\n",
-			&fifo->mem->start);
-		rc = -EBUSY;
-		goto err_initial;
-	}
-	dev_dbg(fifo->dt_device, "got memory location [0x%pa - 0x%pa]\n",
-		&fifo->mem->start, &fifo->mem->end);
-	fifo->fpga_addr = fifo->mem->start;
+    /* request physical memory */
+    if (!request_mem_region(fifo->mem->start, resource_size(fifo->mem),
+                DRIVER_NAME)) {
+        dev_err(fifo->dt_device,
+            "couldn't lock memory region at 0x%pa\n",
+            &fifo->mem->start);
+        rc = -EBUSY;
+        goto err_initial;
+    }
+    dev_dbg(fifo->dt_device, "got memory location [0x%pa - 0x%pa]\n",
+        &fifo->mem->start, &fifo->mem->end);
+    fifo->fpga_addr = fifo->mem->start;
 
-	/* map physical memory to kernel virtual address space */
-	fifo->base_addr = ioremap(fifo->mem->start, resource_size(fifo->mem));
-	if (!fifo->base_addr) {
-		dev_err(fifo->dt_device, "couldn't map physical memory\n");
-		rc = -ENOMEM;
-		goto err_mem;
-	}
-	dev_dbg(fifo->dt_device, "remapped memory to 0x%p\n", fifo->base_addr);
+    /* map physical memory to kernel virtual address space */
+    fifo->base_addr = ioremap(fifo->mem->start, resource_size(fifo->mem));
+    if (!fifo->base_addr) {
+        dev_err(fifo->dt_device, "couldn't map physical memory\n");
+        rc = -ENOMEM;
+        goto err_mem;
+    }
+    dev_dbg(fifo->dt_device, "remapped memory to 0x%p\n", fifo->base_addr);
 
-	/* create unique device name */
-	snprintf(device_name, sizeof(device_name), "%s_%pa",
-		 DRIVER_NAME, &fifo->mem->start);
+    /* create unique device name */
+    snprintf(device_name, sizeof(device_name), "%s_%pa",
+         DRIVER_NAME, &fifo->mem->start);
 
-	dev_dbg(fifo->dt_device, "device name [%s]\n", device_name);
+    dev_dbg(fifo->dt_device, "device name [%s]\n", device_name);
 
-	/* ----------------------------
-	 *          init IP
-	 * ----------------------------
-	 */
+    /* ----------------------------
+     *          init IP
+     * ----------------------------
+     */
 
-	/* retrieve device tree properties */
-	rc = get_dts_property(fifo, "xlnx,axi-str-rxd-tdata-width",
-			      &rxd_tdata_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,axi-str-txc-tdata-width",
-			      &txc_tdata_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,axi-str-txd-tdata-width",
-			      &txd_tdata_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,axis-tdest-width", &tdest_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,axis-tid-width", &tid_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,axis-tuser-width", &tuser_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,data-interface-type",
-			      &data_interface_type);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,has-axis-tdest", &has_tdest);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,has-axis-tid", &has_tid);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,has-axis-tkeep", &has_tkeep);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,has-axis-tstrb", &has_tstrb);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,has-axis-tuser", &has_tuser);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,rx-fifo-depth", &rx_fifo_depth);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,rx-fifo-pe-threshold",
-			      &rx_programmable_empty_threshold);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,rx-fifo-pf-threshold",
-			      &rx_programmable_full_threshold);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,s-axi-id-width", &axi_id_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,s-axi4-data-width", &axi4_data_width);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,select-xpm", &select_xpm);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,tx-fifo-depth", &tx_fifo_depth);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,tx-max-pkt-size", &tx_max_pkt_size);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,rx-min-pkt-size", &rx_min_pkt_size);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,tx-fifo-pe-threshold",
-			      &tx_programmable_empty_threshold);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,tx-fifo-pf-threshold",
-			      &tx_programmable_full_threshold);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,use-rx-cut-through",
-			      &use_rx_cut_through);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,use-rx-data", &use_rx_data);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,use-tx-ctrl", &use_tx_control);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,use-tx-cut-through",
-			      &use_tx_cut_through);
-	if (rc)
-		goto err_unmap;
-	rc = get_dts_property(fifo, "xlnx,use-tx-data", &use_tx_data);
-	if (rc)
-		goto err_unmap;
+    /* retrieve device tree properties */
+    rc = get_dts_property(fifo, "xlnx,axi-str-rxd-tdata-width",
+                  &rxd_tdata_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,axi-str-txc-tdata-width",
+                  &txc_tdata_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,axi-str-txd-tdata-width",
+                  &txd_tdata_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,axis-tdest-width", &tdest_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,axis-tid-width", &tid_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,axis-tuser-width", &tuser_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,data-interface-type",
+                  &data_interface_type);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,has-axis-tdest", &has_tdest);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,has-axis-tid", &has_tid);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,has-axis-tkeep", &has_tkeep);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,has-axis-tstrb", &has_tstrb);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,has-axis-tuser", &has_tuser);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,rx-fifo-depth", &rx_fifo_depth);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,rx-fifo-pe-threshold",
+                  &rx_programmable_empty_threshold);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,rx-fifo-pf-threshold",
+                  &rx_programmable_full_threshold);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,s-axi-id-width", &axi_id_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,s-axi4-data-width", &axi4_data_width);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,select-xpm", &select_xpm);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,tx-fifo-depth", &tx_fifo_depth);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,tx-max-pkt-size", &tx_max_pkt_size);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,rx-min-pkt-size", &rx_min_pkt_size);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,tx-fifo-pe-threshold",
+                  &tx_programmable_empty_threshold);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,tx-fifo-pf-threshold",
+                  &tx_programmable_full_threshold);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,use-rx-cut-through",
+                  &use_rx_cut_through);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,use-rx-data", &use_rx_data);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,use-tx-ctrl", &use_tx_control);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,use-tx-cut-through",
+                  &use_tx_cut_through);
+    if (rc)
+        goto err_unmap;
+    rc = get_dts_property(fifo, "xlnx,use-tx-data", &use_tx_data);
+    if (rc)
+        goto err_unmap;
 
-	/* check validity of device tree properties */
-	if (rxd_tdata_width != 32) {
-		dev_err(fifo->dt_device,
-			"rxd_tdata_width width [%u] unsupported\n",
-			rxd_tdata_width);
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (txd_tdata_width != 32) {
-		dev_err(fifo->dt_device,
-			"txd_tdata_width width [%u] unsupported\n",
-			txd_tdata_width);
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (has_tdest) {
-		dev_err(fifo->dt_device, "tdest not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (has_tid) {
-		dev_err(fifo->dt_device, "tid not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (has_tstrb) {
-		dev_err(fifo->dt_device, "tstrb not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (has_tuser) {
-		dev_err(fifo->dt_device, "tuser not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (use_rx_cut_through) {
-		dev_err(fifo->dt_device, "rx cut-through not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (use_tx_cut_through) {
-		dev_err(fifo->dt_device, "tx cut-through not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
-	if (use_tx_control) {
-		dev_err(fifo->dt_device, "tx control not supported\n");
-		rc = -EIO;
-		goto err_unmap;
-	}
+    /* check validity of device tree properties */
+    if (rxd_tdata_width != 32) {
+        dev_err(fifo->dt_device,
+            "rxd_tdata_width width [%u] unsupported\n",
+            rxd_tdata_width);
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (txd_tdata_width != 32) {
+        dev_err(fifo->dt_device,
+            "txd_tdata_width width [%u] unsupported\n",
+            txd_tdata_width);
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (has_tdest) {
+        dev_err(fifo->dt_device, "tdest not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (has_tid) {
+        dev_err(fifo->dt_device, "tid not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (has_tstrb) {
+        dev_err(fifo->dt_device, "tstrb not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (has_tuser) {
+        dev_err(fifo->dt_device, "tuser not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (use_rx_cut_through) {
+        dev_err(fifo->dt_device, "rx cut-through not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (use_tx_cut_through) {
+        dev_err(fifo->dt_device, "tx cut-through not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
+    if (use_tx_control) {
+        dev_err(fifo->dt_device, "tx control not supported\n");
+        rc = -EIO;
+        goto err_unmap;
+    }
 
-	/* TODO
-	 * these exist in the device tree but it's unclear what they do
-	 * - select-xpm
-	 * - data-interface-type
-	 */
+    /* TODO
+     * these exist in the device tree but it's unclear what they do
+     * - select-xpm
+     * - data-interface-type
+     */
 
-	/* set device wrapper properties based on IP config */
-	fifo->rx_fifo_depth = rx_fifo_depth;
-	/* IP sets TDFV to fifo depth - 4 so we will do the same */
-	fifo->tx_fifo_depth = tx_fifo_depth - 4;
-	fifo->rx_fifo_pf_thresh = rx_programmable_full_threshold;
-	fifo->tx_fifo_pf_thresh = tx_programmable_full_threshold;
-	fifo->rx_fifo_pe_thresh = rx_programmable_empty_threshold;
-	fifo->tx_fifo_pe_thresh = tx_programmable_empty_threshold;
-	fifo->has_rx_fifo = !!use_rx_data;
-	fifo->has_tx_fifo = !!use_tx_data;
-	fifo->has_tkeep = !!has_tkeep;
-	fifo->tx_max_pkt_size = tx_max_pkt_size;
-	fifo->rx_min_pkt_size = rx_min_pkt_size;
+    /* set device wrapper properties based on IP config */
+    fifo->rx_fifo_depth = rx_fifo_depth;
+    /* IP sets TDFV to fifo depth - 4 so we will do the same */
+    fifo->tx_fifo_depth = tx_fifo_depth - 4;
+    fifo->rx_fifo_pf_thresh = rx_programmable_full_threshold;
+    fifo->tx_fifo_pf_thresh = tx_programmable_full_threshold;
+    fifo->rx_fifo_pe_thresh = rx_programmable_empty_threshold;
+    fifo->tx_fifo_pe_thresh = tx_programmable_empty_threshold;
+    fifo->has_rx_fifo = !!use_rx_data;
+    fifo->has_tx_fifo = !!use_tx_data;
+    fifo->has_tkeep = !!has_tkeep;
+    fifo->tx_max_pkt_size = tx_max_pkt_size;
+    fifo->rx_min_pkt_size = rx_min_pkt_size;
 
-	reset_ip_core(fifo);
+    reset_ip_core(fifo);
 
-	/* ----------------------------
-	 *    init device interrupts
-	 * ----------------------------
-	 */
+    /* ----------------------------
+     *    init device interrupts
+     * ----------------------------
+     */
 
-	/* get IRQ resource */
-	r_irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
-	if (!r_irq) {
-		dev_err(fifo->dt_device, "no IRQ found for 0x%pa\n",
-			&fifo->mem->start);
-		rc = -EIO;
-		goto err_unmap;
-	}
+    /* get IRQ resource */
+    r_irq = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
+    if (!r_irq) {
+        dev_err(fifo->dt_device, "no IRQ found for 0x%pa\n",
+            &fifo->mem->start);
+        rc = -EIO;
+        goto err_unmap;
+    }
 
-	/* request IRQ */
-	fifo->irq = r_irq->start;
-	rc = request_irq(fifo->irq, &axis_fifo_irq, 0, DRIVER_NAME, fifo);
-	if (rc) {
-		dev_err(fifo->dt_device, "couldn't allocate interrupt %i\n",
-			fifo->irq);
-		goto err_unmap;
-	}
+    /* request IRQ */
+    fifo->irq = r_irq->start;
+    rc = request_irq(fifo->irq, &axis_fifo_irq, 0, DRIVER_NAME, fifo);
+    if (rc) {
+        dev_err(fifo->dt_device, "couldn't allocate interrupt %i\n",
+            fifo->irq);
+        goto err_unmap;
+    }
 
-	/* ----------------------------
-	 *      init char device
-	 * ----------------------------
-	 */
+    /* ----------------------------
+     *      init char device
+     * ----------------------------
+     */
 
-	/* allocate device number */
-	rc = alloc_chrdev_region(&fifo->devt, 0, 1, DRIVER_NAME);
-	if (rc < 0)
-		goto err_irq;
-	dev_dbg(fifo->dt_device, "allocated device number major %i minor %i\n",
-		MAJOR(fifo->devt), MINOR(fifo->devt));
+    /* allocate device number */
+    rc = alloc_chrdev_region(&fifo->devt, 0, 1, DRIVER_NAME);
+    if (rc < 0)
+        goto err_irq;
+    dev_dbg(fifo->dt_device, "allocated device number major %i minor %i\n",
+        MAJOR(fifo->devt), MINOR(fifo->devt));
 
-	/* create driver file */
-	fifo->device = device_create(axis_fifo_driver_class, NULL, fifo->devt,
-				     NULL, device_name);
-	if (IS_ERR(fifo->device)) {
-		dev_err(fifo->dt_device,
-			"couldn't create driver file\n");
-		rc = PTR_ERR(fifo->device);
-		goto err_chrdev_region;
-	}
-	dev_set_drvdata(fifo->device, fifo);
+    /* create driver file */
+    fifo->device = device_create(axis_fifo_driver_class, NULL, fifo->devt,
+                     NULL, device_name);
+    if (IS_ERR(fifo->device)) {
+        dev_err(fifo->dt_device,
+            "couldn't create driver file\n");
+        rc = PTR_ERR(fifo->device);
+        goto err_chrdev_region;
+    }
+    dev_set_drvdata(fifo->device, fifo);
 
-	/* create character device */
-	cdev_init(&fifo->char_device, &fops);
-	rc = cdev_add(&fifo->char_device, fifo->devt, 1);
-	if (rc < 0) {
-		dev_err(fifo->dt_device, "couldn't create character device\n");
-		goto err_dev;
-	}
+    /* create character device */
+    cdev_init(&fifo->char_device, &fops);
+    rc = cdev_add(&fifo->char_device, fifo->devt, 1);
+    if (rc < 0) {
+        dev_err(fifo->dt_device, "couldn't create character device\n");
+        goto err_dev;
+    }
 
-	/* create sysfs entries */
-	rc = sysfs_create_group(&fifo->device->kobj, &axis_fifo_attrs_group);
-	if (rc < 0) {
-		dev_err(fifo->dt_device, "couldn't register sysfs group\n");
-		goto err_cdev;
-	}
+    /* create sysfs entries */
+    rc = sysfs_create_group(&fifo->device->kobj, &axis_fifo_attrs_group);
+    if (rc < 0) {
+        dev_err(fifo->dt_device, "couldn't register sysfs group\n");
+        goto err_cdev;
+    }
 
-	dev_info(fifo->dt_device, "axis-fifo created at %pa mapped to 0x%pa, irq=%i, major=%i, minor=%i\n",
-		 &fifo->mem->start, &fifo->base_addr, fifo->irq,
-		 MAJOR(fifo->devt), MINOR(fifo->devt));
+    dev_info(fifo->dt_device, "axis-fifo created at %pa mapped to 0x%pa, irq=%i, major=%i, minor=%i\n",
+         &fifo->mem->start, &fifo->base_addr, fifo->irq,
+         MAJOR(fifo->devt), MINOR(fifo->devt));
 
-	return 0;
+    return 0;
 
 err_cdev:
-	cdev_del(&fifo->char_device);
+    cdev_del(&fifo->char_device);
 err_dev:
-	device_destroy(axis_fifo_driver_class, fifo->devt);
+    device_destroy(axis_fifo_driver_class, fifo->devt);
 err_chrdev_region:
-	unregister_chrdev_region(fifo->devt, 1);
+    unregister_chrdev_region(fifo->devt, 1);
 err_irq:
-	free_irq(fifo->irq, fifo);
+    free_irq(fifo->irq, fifo);
 err_unmap:
-	iounmap(fifo->base_addr);
+    iounmap(fifo->base_addr);
 err_mem:
-	release_mem_region(fifo->mem->start, resource_size(fifo->mem));
+    release_mem_region(fifo->mem->start, resource_size(fifo->mem));
 err_initial:
-	dev_set_drvdata(dev, NULL);
-	return rc;
+    dev_set_drvdata(dev, NULL);
+    return rc;
 }
 
 static int axis_fifo_remove(struct platform_device *pdev)
 {
-	struct device *dev = &pdev->dev;
-	struct axis_fifo *fifo = dev_get_drvdata(dev);
+    struct device *dev = &pdev->dev;
+    struct axis_fifo *fifo = dev_get_drvdata(dev);
 
-	sysfs_remove_group(&fifo->device->kobj, &axis_fifo_attrs_group);
-	cdev_del(&fifo->char_device);
-	dev_set_drvdata(fifo->device, NULL);
-	device_destroy(axis_fifo_driver_class, fifo->devt);
-	unregister_chrdev_region(fifo->devt, 1);
-	free_irq(fifo->irq, fifo);
-	iounmap(fifo->base_addr);
-	release_mem_region(fifo->mem->start, resource_size(fifo->mem));
-	dev_set_drvdata(dev, NULL);
-	return 0;
+    sysfs_remove_group(&fifo->device->kobj, &axis_fifo_attrs_group);
+    cdev_del(&fifo->char_device);
+    dev_set_drvdata(fifo->device, NULL);
+    device_destroy(axis_fifo_driver_class, fifo->devt);
+    unregister_chrdev_region(fifo->devt, 1);
+    free_irq(fifo->irq, fifo);
+    iounmap(fifo->base_addr);
+    release_mem_region(fifo->mem->start, resource_size(fifo->mem));
+    dev_set_drvdata(dev, NULL);
+    return 0;
 }
 
 static const struct of_device_id axis_fifo_of_match[] = {
-	{ .compatible = "xlnx,axi-fifo-mm-s-4.1", },
-	{ .compatible = "xlnx,axi-fifo-mm-s-4.2", },
-	{},
+    { .compatible = "xlnx,axi-fifo-mm-s-4.1", },
+    { .compatible = "xlnx,axi-fifo-mm-s-4.2", },
+    {},
 };
 MODULE_DEVICE_TABLE(of, axis_fifo_of_match);
 
 static struct platform_driver axis_fifo_driver = {
-	.driver = {
-		.name = DRIVER_NAME,
-		.owner = THIS_MODULE,
-		.of_match_table	= axis_fifo_of_match,
-	},
-	.probe		= axis_fifo_probe,
-	.remove		= axis_fifo_remove,
+    .driver = {
+        .name = DRIVER_NAME,
+        .owner = THIS_MODULE,
+        .of_match_table = axis_fifo_of_match,
+    },
+    .probe      = axis_fifo_probe,
+    .remove     = axis_fifo_remove,
 };
 
 static int __init axis_fifo_init(void)
 {
-	pr_info("axis-fifo driver loaded with parameters read_timeout = %i, write_timeout = %i\n",
-		read_timeout, write_timeout);
-	axis_fifo_driver_class = class_create(THIS_MODULE, DRIVER_NAME);
-	if (IS_ERR(axis_fifo_driver_class))
-		return PTR_ERR(axis_fifo_driver_class);
-	return platform_driver_register(&axis_fifo_driver);
+    pr_info("axis-fifo driver loaded with parameters read_timeout = %i, write_timeout = %i\n",
+        read_timeout, write_timeout);
+    axis_fifo_driver_class = class_create(THIS_MODULE, DRIVER_NAME);
+    if (IS_ERR(axis_fifo_driver_class))
+        return PTR_ERR(axis_fifo_driver_class);
+    return platform_driver_register(&axis_fifo_driver);
 }
 
 module_init(axis_fifo_init);
 
 static void __exit axis_fifo_exit(void)
 {
-	platform_driver_unregister(&axis_fifo_driver);
-	class_destroy(axis_fifo_driver_class);
+    platform_driver_unregister(&axis_fifo_driver);
+    class_destroy(axis_fifo_driver_class);
 }
 
 module_exit(axis_fifo_exit);

--- a/axis-fifo.h
+++ b/axis-fifo.h
@@ -58,12 +58,11 @@
 #define XLLF_INT_TXERROR_MASK     0x12000000 /* Transmit Error status ints */
 
 /* ----------------------------
- *      ioctls 
+ *      ioctls
  * ----------------------------
  */
-
 #define AXIS_FIFO_IOCTL_MAGIC 'Q'
-#define AXIS_FIFO_NUM_IOCTLS 8
+#define AXIS_FIFO_NUM_IOCTLS 9
 
 
 struct axis_fifo_kern_regInfo{
@@ -79,5 +78,6 @@ struct axis_fifo_kern_regInfo{
 #define AXIS_FIFO_SET_RX_MIN_PKT  _IOW(AXIS_FIFO_IOCTL_MAGIC, 5,  uint32_t)
 #define AXIS_FIFO_RESET_IP        _IO(AXIS_FIFO_IOCTL_MAGIC,6)
 #define AXIS_FIFO_GET_FPGA_ADDR   _IOR(AXIS_FIFO_IOCTL_MAGIC,7, uint32_t)
+#define AXIS_FIFO_GET_TX_VACANCY  _IOR(AXIS_FIFO_IOCTL_MAGIC, 8, uint32_t)
 
 #endif /* AXIS_FIFO_H */

--- a/axis-fifo.h
+++ b/axis-fifo.h
@@ -62,7 +62,7 @@
  * ----------------------------
  */
 #define AXIS_FIFO_IOCTL_MAGIC 'Q'
-#define AXIS_FIFO_NUM_IOCTLS 10
+#define AXIS_FIFO_NUM_IOCTLS 14
 
 
 struct axis_fifo_kern_regInfo{
@@ -80,5 +80,9 @@ struct axis_fifo_kern_regInfo{
 #define AXIS_FIFO_GET_FPGA_ADDR   _IOR(AXIS_FIFO_IOCTL_MAGIC,7, uint32_t)
 #define AXIS_FIFO_GET_TX_VACANCY  _IOR(AXIS_FIFO_IOCTL_MAGIC, 8, uint32_t)
 #define AXIS_FIFO_GET_RX_OCCUPANCY _IOR(AXIS_FIFO_IOCTL_MAGIC, 9, uint32_t)
+#define AXIS_FIFO_GET_TX_PKTS_SENT _IOR(AXIS_FIFO_IOCTL_MAGIC, 10, uint32_t)
+#define AXIS_FIFO_GET_TX_BYTES_SENT _IOR(AXIS_FIFO_IOCTL_MAGIC, 11, uint32_t)
+#define AXIS_FIFO_GET_RX_PKTS_READ _IOR(AXIS_FIFO_IOCTL_MAGIC, 12, uint32_t)
+#define AXIS_FIFO_GET_RX_BYTES_READ _IOR(AXIS_FIFO_IOCTL_MAGIC, 13, uint32_t)
 
 #endif /* AXIS_FIFO_H */

--- a/axis-fifo.h
+++ b/axis-fifo.h
@@ -62,7 +62,7 @@
  * ----------------------------
  */
 #define AXIS_FIFO_IOCTL_MAGIC 'Q'
-#define AXIS_FIFO_NUM_IOCTLS 9
+#define AXIS_FIFO_NUM_IOCTLS 10
 
 
 struct axis_fifo_kern_regInfo{
@@ -79,5 +79,6 @@ struct axis_fifo_kern_regInfo{
 #define AXIS_FIFO_RESET_IP        _IO(AXIS_FIFO_IOCTL_MAGIC,6)
 #define AXIS_FIFO_GET_FPGA_ADDR   _IOR(AXIS_FIFO_IOCTL_MAGIC,7, uint32_t)
 #define AXIS_FIFO_GET_TX_VACANCY  _IOR(AXIS_FIFO_IOCTL_MAGIC, 8, uint32_t)
+#define AXIS_FIFO_GET_RX_OCCUPANCY _IOR(AXIS_FIFO_IOCTL_MAGIC, 9, uint32_t)
 
 #endif /* AXIS_FIFO_H */


### PR DESCRIPTION
- Added the following IOCTL / sysfs reads for long term monitoring,
    - #define AXIS_FIFO_GET_TX_VACANCY  _IOR(AXIS_FIFO_IOCTL_MAGIC, 8, uint32_t)
    - #define AXIS_FIFO_GET_RX_OCCUPANCY _IOR(AXIS_FIFO_IOCTL_MAGIC, 9, uint32_t)
    - #define AXIS_FIFO_GET_TX_PKTS_SENT _IOR(AXIS_FIFO_IOCTL_MAGIC, 10, uint32_t)
    - #define AXIS_FIFO_GET_TX_BYTES_SENT _IOR(AXIS_FIFO_IOCTL_MAGIC, 11, uint32_t)
    - #define AXIS_FIFO_GET_RX_PKTS_READ _IOR(AXIS_FIFO_IOCTL_MAGIC, 12, uint32_t)
    - #define AXIS_FIFO_GET_RX_BYTES_READ _IOR(AXIS_FIFO_IOCTL_MAGIC, 13, uint32_t)
- Added axis-fifo-echo-test for quickly writing and reading to a fifo from threaded app for testing
- Improved performance of axis-fifo-ethernet-bridge, extensively tested
- Added ability to write sub word (1|2|3 byte) packets to the transmit fifo