### PR TITLE
Change Kbuild/make convention from SUBDIRS to M

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 obj-m := axis-fifo.o
 
+SRC := $(shell pwd)
+
 all:
-	$(MAKE) -C $(KDIR) SUBDIRS=`pwd` modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules
 
 clean:
-	$(MAKE) -C $(KDIR) SUBDIRS=`pwd` clean
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) clean
 
 modules_install:
-	$(MAKE) -C $(KDIR) SUBDIRS=`pwd` modules_install
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install


### PR DESCRIPTION
SUBDIRS support was [removed after kernel 5.3](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7e35b42591c058b91282f95ce3b2cf0c05ffe93d).  In order to compile this kernel module until Petalinux 2020.2 (kernel 5.4) I had to modify the Makefile accordingly.



Unfortunately it's not easy for me to roll back and test to see if this approach also works under older versions of Petalinux.