### PR TITLE
Added `axi-fifo` v4.3 IP compatibility string and tested on Petalinux 2024.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xilinx AXI-Stream FIFO v4.1/v4.2 IP core driver
+# Xilinx AXI-Stream FIFO v4.1/v4.2/v4.3 IP core driver
 
 This IP core has read and write AXI-Stream FIFOs, the contents of which can be accessed from the AXI4 memory-mapped interface. This is useful for transferring data from a processor into the FPGA fabric. The driver creates a character device that can be read/written to with standard open/read/write/close.
 

--- a/axis-fifo.c
+++ b/axis-fifo.c
@@ -1444,6 +1444,7 @@ static int axis_fifo_remove(struct platform_device *pdev)
 static const struct of_device_id axis_fifo_of_match[] = {
     { .compatible = "xlnx,axi-fifo-mm-s-4.1", },
     { .compatible = "xlnx,axi-fifo-mm-s-4.2", },
+    { .compatible = "xlnx,axi-fifo-mm-s-4.3", },
     {},
 };
 MODULE_DEVICE_TABLE(of, axis_fifo_of_match);


### PR DESCRIPTION
Updated README to reflect v.4.3 IP compatibility